### PR TITLE
Define estimators as immutables

### DIFF
--- a/src/pi0-estimators.jl
+++ b/src/pi0-estimators.jl
@@ -22,7 +22,7 @@ Storey, JD (2002). "A Direct Approach to False Discovery Rates." Journal of the
 Royal Statistical Society, doi:10.1111/1467-9868.00346
 
 """
-type Storey <: Pi0Estimator
+immutable Storey <: Pi0Estimator
     λ::AbstractFloat
 
     Storey(λ) = isin(λ, 0., 1.) ? new(λ) : throw(DomainError())
@@ -50,7 +50,7 @@ StoreyBootstrap(λseq, q)
 
 Reference: David Robinson, 2012
 """
-type StoreyBootstrap <: Pi0Estimator
+immutable StoreyBootstrap <: Pi0Estimator
     ## check range of arguments
     λseq::Vector{AbstractFloat}
     q   ::AbstractFloat
@@ -84,7 +84,7 @@ Least SLope (LSL) π0 estimator
 
 LeastSlope()
 """
-type LeastSlope <: Pi0Estimator
+immutable LeastSlope <: Pi0Estimator
 end
 
 function estimate_pi0{T<:AbstractFloat}(pValues::Vector{T}, pi0estimator::LeastSlope)
@@ -136,7 +136,7 @@ Oracle π0
 
 Oracle(π0)
 """
-type Oracle <: Pi0Estimator
+immutable Oracle <: Pi0Estimator
     π0::AbstractFloat
 
     Oracle(π0) = isin(π0, 0., 1.) ? new(π0) : throw(DomainError())
@@ -158,7 +158,7 @@ TwoStep(α)
 
 Reference: Benjamini, Krieger and Yekutieli, 2006
 """
-type TwoStep <: Pi0Estimator
+immutable TwoStep <: Pi0Estimator
     α::AbstractFloat
     ## method::PValueAdjustmentMethod
 
@@ -185,7 +185,7 @@ Right boundary π0 estimator
 
 RightBoundary(λseq)
 """
-type RightBoundary <: Pi0Estimator
+immutable RightBoundary <: Pi0Estimator
     ## check range of arguments
     λseq::Vector{Float64}
 
@@ -224,7 +224,7 @@ Censored BUM π0 estimator
 
 CensoredBUM(γ0, λ, xtol, maxiter)
 """
-type CensoredBUM <: Pi0Estimator
+immutable CensoredBUM <: Pi0Estimator
     γ0::Float64
     λ::Float64
     xtol::Float64
@@ -242,7 +242,7 @@ end
 CensoredBUM() = CensoredBUM(0.5, 0.05, 1e-6, 10000)
 CensoredBUM(γ0, λ) = CensoredBUM(γ0, λ, 1e-6, 10000)
 
-type CensoredBUMFit <: Pi0Fit
+immutable CensoredBUMFit <: Pi0Fit
     π0::Float64
     param::Vector{Float64}
     is_converged::Bool
@@ -336,7 +336,7 @@ BUM π0 estimator
 
 BUM(γ0, xtol, maxiter)
 """
-type BUM <: Pi0Estimator
+immutable BUM <: Pi0Estimator
     γ0::Float64
     xtol::Float64
     maxiter::Int64
@@ -354,7 +354,7 @@ BUM() = BUM(0.5, 1e-6, 10000)
 
 BUM(y0::Float64) = BUM(y0, 1e-6, 10000)
 
-type BUMFit <: Pi0Fit
+immutable BUMFit <: Pi0Fit
     π0::Float64
     param::Vector{Float64}
     is_converged::Bool
@@ -390,7 +390,7 @@ Estimates π0 by the longest constant interval in the Grenander estimator
 
 Reference: Langaas et al., 2005: section 4.3
 """
-type FlatGrenander <: Pi0Estimator
+immutable FlatGrenander <: Pi0Estimator
 end
 
 function estimate_pi0{T<:AbstractFloat}(pValues::Vector{T}, pi0estimator::FlatGrenander)

--- a/src/pval-adjustment.jl
+++ b/src/pval-adjustment.jl
@@ -1,6 +1,6 @@
 ## p-value adjustment methods ##
 
-type Bonferroni <: PValueAdjustmentMethod
+immutable Bonferroni <: PValueAdjustmentMethod
 end
 
 adjust(pvals, method::Bonferroni) = bonferroni(pvals)
@@ -10,7 +10,7 @@ function bonferroni{T<:AbstractFloat}(pValues::Vector{T})
     return min(pValues * length(pValues), 1.)
 end
 
-type BenjaminiHochberg <: PValueAdjustmentMethod
+immutable BenjaminiHochberg <: PValueAdjustmentMethod
 end
 
 adjust(pvals, method::BenjaminiHochberg) = benjamini_hochberg(pvals)
@@ -29,7 +29,7 @@ end
 
 bejamini_hochberg_multiplier(i::Int, n::Int) = n/(n-i)
 
-type BenjaminiHochbergAdaptive <: PValueAdjustmentMethod
+immutable BenjaminiHochbergAdaptive <: PValueAdjustmentMethod
     pi0estimator::Pi0Estimator
 end
 
@@ -49,7 +49,7 @@ function benjamini_hochberg{T<:AbstractFloat}(pValues::Vector{T}, pi0::T)
 end
 
 
-type BenjaminiYekutieli <: PValueAdjustmentMethod
+immutable BenjaminiYekutieli <: PValueAdjustmentMethod
 end
 
 adjust(pvals, method::BenjaminiYekutieli) = benjamini_yekutieli(pvals)
@@ -71,7 +71,7 @@ function benjamini_yekutieli_multiplier(i::Int, n::Int)
     return ((n*c)/(n-i))
 end
 
-type BenjaminiLiu <: PValueAdjustmentMethod
+immutable BenjaminiLiu <: PValueAdjustmentMethod
 end
 
 adjust(pvals, method::BenjaminiLiu) = benjamini_liu(pvals)
@@ -99,7 +99,7 @@ function benjamini_liu_step{T<:AbstractFloat}(p::T, i::Int, n::Int)
     end
 end
 
-type Hochberg <: PValueAdjustmentMethod
+immutable Hochberg <: PValueAdjustmentMethod
 end
 
 adjust(pvals, method::Hochberg) = hochberg(pvals)
@@ -119,7 +119,7 @@ end
 hochberg_multiplier(i::Int, n::Int) = (i+1)
 
 
-type Holm <: PValueAdjustmentMethod
+immutable Holm <: PValueAdjustmentMethod
 end
 
 adjust(pvals, method::Holm) = holm(pvals)
@@ -139,7 +139,7 @@ end
 holm_multiplier(i::Int, n::Int) = (n-i+1)
 
 
-type Hommel <: PValueAdjustmentMethod
+immutable Hommel <: PValueAdjustmentMethod
 end
 
 adjust(pvals, method::Hommel) = hommel(pvals)
@@ -166,7 +166,7 @@ function hommel{T<:AbstractFloat}(pValues::Vector{T})
 end
 
 
-type Sidak <: PValueAdjustmentMethod
+immutable Sidak <: PValueAdjustmentMethod
 end
 
 adjust(pvals, method::Sidak) = sidak(pvals)
@@ -176,7 +176,7 @@ function sidak{T<:AbstractFloat}(pValues::Vector{T})
     return min(1-(1-pValues).^length(pValues), 1.)
 end
 
-type ForwardStop <: PValueAdjustmentMethod
+immutable ForwardStop <: PValueAdjustmentMethod
 end
 
 adjust(pvals, method::ForwardStop) = forwardstop(pvals)


### PR DESCRIPTION
Make use of immutable types for defining estimators/methods.