### PR TITLE
Define and integrate `PValues` type

### DIFF
--- a/src/MultipleTesting.jl
+++ b/src/MultipleTesting.jl
@@ -42,7 +42,8 @@ export
     FlatGrenander,
     isin,
     fit,
-    BetaUniformMixtureModel
+    BetaUniformMixtureModel,
+    PValues
 
 include("types.jl")
 include("utils.jl")

--- a/src/pval-adjustment.jl
+++ b/src/pval-adjustment.jl
@@ -46,7 +46,7 @@ function adjust(pvals::PValues, method::BenjaminiHochbergAdaptive)
 end
 
 function benjamini_hochberg{T<:AbstractFloat}(pValues::PValues, pi0::T)
-    validPValues([pi0])
+    valid_pvalues([pi0])
     benjamini_hochberg(pValues) .* pi0
 end
 

--- a/src/qvalue.jl
+++ b/src/qvalue.jl
@@ -1,6 +1,6 @@
 ## qValues ##
 
-function qValues{T<:AbstractFloat}(pValues::Vector{T}, pi0::T, pfdr::Bool = false)
+function qValues{T<:AbstractFloat}(pValues::AbstractVector{T}, pi0::T, pfdr::Bool = false)
     validPValues(pValues)
     validPValues([pi0])
     n = length(pValues)

--- a/src/qvalue.jl
+++ b/src/qvalue.jl
@@ -1,8 +1,8 @@
 ## qValues ##
 
 function qValues{T<:AbstractFloat}(pValues::AbstractVector{T}, pi0::T, pfdr::Bool = false)
-    validPValues(pValues)
-    validPValues([pi0])
+    valid_pvalues(pValues)
+    valid_pvalues([pi0])
     n = length(pValues)
     u = sortperm(pValues)
     v = competerank(pValues) ## ties with 'min'

--- a/src/types.jl
+++ b/src/types.jl
@@ -16,19 +16,13 @@ type PValues{T<:AbstractFloat} <: AbstractVector{T}
     min::T
     max::T
 
-    function PValues(values::AbstractVector{T}, min::T, max::T)
+    function(::Type{PValues}){T}(values::AbstractVector{T})
+        min, max = extrema(values)
         if min < 0.0 || max > 1.0
             throw(DomainError())
         end
-        new(values, min, max)
+        new{T}(values, min, max)
     end
-end
-
-PValues{T<:AbstractFloat}(values::AbstractVector{T}, min::T, max::T) = PValues{T}(values, min, max)
-
-function PValues{T<:AbstractFloat}(values::AbstractVector{T})
-    minp, maxp = extrema(values)
-    PValues(values, minp, maxp)
 end
 
 Base.convert{T<:AbstractFloat}(::Type{PValues}, x::AbstractVector{T}) = PValues(x)

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,9 +7,9 @@ abstract Pi0Fit
 abstract PValueAdjustmentMethod
 
 
-## types ##
+## concrete types ##
 
-# PValues
+## PValues
 
 type PValues{T<:AbstractFloat} <: AbstractVector{T}
     values::AbstractVector{T}
@@ -31,7 +31,7 @@ function PValues{T<:AbstractFloat}(values::AbstractVector{T})
     PValues(values, minp, maxp)
 end
 
-Base.convert{T<:AbstractFloat}(::Type{PValues}, x::AbstractVector{T}) = PValues(x) # TODO define test
+Base.convert{T<:AbstractFloat}(::Type{PValues}, x::AbstractVector{T}) = PValues(x)
 
 Base.size(pv::PValues) = (length(pv.values), )
 Base.linearindexing{T<:PValues}(::Type{T}) = Base.LinearFast()
@@ -41,6 +41,4 @@ Base.values(pv::PValues) = pv.values
 Base.minimum(pv::PValues) = pv.min
 Base.maximum(pv::PValues) = pv.max
 Base.extrema(pv::PValues) = (minimum(pv), maximum(pv))
-# not essential: defaults to prod(size(pv))
-# store in extra field 'n'?
 Base.length(pv::PValues) = length(pv.values)

--- a/src/types.jl
+++ b/src/types.jl
@@ -12,11 +12,11 @@ abstract PValueAdjustmentMethod
 # PValues
 
 type PValues{T<:AbstractFloat} <: AbstractVector{T}
-    values::Vector{T}
+    values::AbstractVector{T}
     min::T
     max::T
 
-    function PValues(values::Vector{T}, min::T, max::T)
+    function PValues(values::AbstractVector{T}, min::T, max::T)
         if min < 0.0 || max > 1.0
             throw(DomainError())
         end
@@ -24,12 +24,14 @@ type PValues{T<:AbstractFloat} <: AbstractVector{T}
     end
 end
 
-PValues{T<:AbstractFloat}(values::Vector{T}, min::T, max::T) = PValues{T}(values, min, max)
+PValues{T<:AbstractFloat}(values::AbstractVector{T}, min::T, max::T) = PValues{T}(values, min, max)
 
-function PValues{T<:AbstractFloat}(values::Vector{T})
+function PValues{T<:AbstractFloat}(values::AbstractVector{T})
     minp, maxp = extrema(values)
     PValues(values, minp, maxp)
 end
+
+Base.convert{T<:AbstractFloat}(::Type{PValues}, x::AbstractVector{T}) = PValues(x) # TODO define test
 
 Base.size(pv::PValues) = (length(pv.values), )
 Base.linearindexing{T<:PValues}(::Type{T}) = Base.LinearFast()

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,44 @@
+## abstract types ##
+
 abstract Pi0Estimator
 
 abstract Pi0Fit
 
 abstract PValueAdjustmentMethod
+
+
+## types ##
+
+# PValues
+
+type PValues{T<:AbstractFloat} <: AbstractVector{T}
+    values::Vector{T}
+    min::T
+    max::T
+
+    function PValues(values::Vector{T}, min::T, max::T)
+        if min < 0.0 || max > 1.0
+            throw(DomainError())
+        end
+        new(values, min, max)
+    end
+end
+
+PValues{T<:AbstractFloat}(values::Vector{T}, min::T, max::T) = PValues{T}(values, min, max)
+
+function PValues{T<:AbstractFloat}(values::Vector{T})
+    minp, maxp = extrema(values)
+    PValues(values, minp, maxp)
+end
+
+Base.size(pv::PValues) = (length(pv.values), )
+Base.linearindexing{T<:PValues}(::Type{T}) = Base.LinearFast()
+Base.getindex(pv::PValues, i::Int) = pv.values[i]
+
+Base.values(pv::PValues) = pv.values
+Base.minimum(pv::PValues) = pv.min
+Base.maximum(pv::PValues) = pv.max
+Base.extrema(pv::PValues) = (minimum(pv), maximum(pv))
+# not essential: defaults to prod(size(pv))
+# store in extra field 'n'?
+Base.length(pv::PValues) = length(pv.values)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 ## utility functions ##
 
-function stepup!{T<:AbstractFloat}(sortedPValues::Vector{T}, multiplier::Function, n::Integer = length(sortedPValues))
+function stepup!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, multiplier::Function, n::Integer = length(sortedPValues))
     sortedPValues[n] *= multiplier(0, n)
     for i in 1:(n-1)
         sortedPValues[n-i] = min(sortedPValues[n-i+1], sortedPValues[n-i] * multiplier(i, n))
@@ -9,13 +9,13 @@ function stepup!{T<:AbstractFloat}(sortedPValues::Vector{T}, multiplier::Functio
 end
 
 # multiplier stepdown
-function stepdown!{T<:AbstractFloat}(sortedPValues::Vector{T}, multiplier::Function, n::Integer = length(sortedPValues))
+function stepdown!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, multiplier::Function, n::Integer = length(sortedPValues))
   stepfun(p::T, i::Int, n::Int) = p * multiplier(i, n)
   general_stepdown!(sortedPValues, stepfun, n)
   return sortedPValues
 end
 
-function general_stepdown!{T<:AbstractFloat}(sortedPValues::Vector{T}, stepfun::Function, n::Integer = length(sortedPValues))
+function general_stepdown!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, stepfun::Function, n::Integer = length(sortedPValues))
     sortedPValues[1] = stepfun(sortedPValues[1], 1, n)
     for i in 2:n
         sortedPValues[i] = max(sortedPValues[i-1], stepfun(sortedPValues[i], i, n))
@@ -23,15 +23,16 @@ function general_stepdown!{T<:AbstractFloat}(sortedPValues::Vector{T}, stepfun::
     return sortedPValues
 end
 
-
-function reorder{T<:Number}(values::Vector{T})
+function reorder{T<:Real}(values::AbstractVector{T})
     newOrder = sortperm(values)
     oldOrder = sortperm(newOrder)
     return newOrder, oldOrder
 end
 
+reorder(pv::PValues) = reorder(values(pv))
 
-function validPValues{T<:AbstractFloat}(x::Vector{T})
+
+function validPValues{T<:AbstractFloat}(x::AbstractVector{T})
     if !isin(x)
         throw(DomainError())
     end
@@ -42,13 +43,13 @@ function isin(x::Real, lower::Real = 0., upper::Real = 1.)
     x >= lower && x <= upper
 end
 
-function isin{T<:Real}(x::Vector{T}, lower::Real = 0., upper::Real = 1.)
+function isin{T<:Real}(x::AbstractVector{T}, lower::Real = 0., upper::Real = 1.)
     ex = extrema(x)
     ex[1] >= lower && ex[2] <= upper
 end
 
 
-function isotonic_regression_reference{T<:AbstractFloat}(y::Vector{T}, w::Vector{T})
+function isotonic_regression_reference{T<:AbstractFloat}(y::AbstractVector{T}, w::AbstractVector{T})
     #todo: ignore zero weights
     y = copy(y)
     w = copy(w)
@@ -72,12 +73,12 @@ function isotonic_regression_reference{T<:AbstractFloat}(y::Vector{T}, w::Vector
     return yisotonic
 end
 
-function isotonic_regression_reference{T<:AbstractFloat}(y::Vector{T})
+function isotonic_regression_reference{T<:AbstractFloat}(y::AbstractVector{T})
     isotonic_regression_reference(y, ones(y))
 end
 
 
-function isotonic_regression{T<:AbstractFloat}(y::Vector{T}, weights::Vector{T})
+function isotonic_regression{T<:AbstractFloat}(y::AbstractVector{T}, weights::AbstractVector{T})
     n = length(y)
     if n <= 1
         return y
@@ -118,12 +119,12 @@ function isotonic_regression{T<:AbstractFloat}(y::Vector{T}, weights::Vector{T})
     return y
 end
 
-function isotonic_regression{T<:AbstractFloat}(y::Vector{T})
+function isotonic_regression{T<:AbstractFloat}(y::AbstractVector{T})
     isotonic_regression(y, ones(y))
 end
 
 
-function grenander{T<:AbstractFloat}(pv::Vector{T})
+function grenander{T<:AbstractFloat}(pv::AbstractVector{T})
     pv_sorted = sort(pv)
     ## ecdf that handles duplicated values
     pv_sorted_unique, counts = rle(pv_sorted)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,7 +32,7 @@ end
 reorder(pv::PValues) = reorder(values(pv))
 
 
-function validPValues{T<:AbstractFloat}(x::AbstractVector{T})
+function valid_pvalues{T<:AbstractFloat}(x::AbstractVector{T})
     if !isin(x)
         throw(DomainError())
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,8 @@ tests = ["test-pval-adjustment",
          "test-pi0-estimators",
          "test-grenander",
          "test-utils",
-         "test-model"
+         "test-model",
+         "test-types"
          ]
 
 for t in tests

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -1,0 +1,44 @@
+## Test types ##
+module Test_types
+
+using MultipleTesting
+using Base.Test
+
+@testset "Types" begin
+
+    @testset "PValues type" begin
+
+        n = 10
+        vals = rand(n)
+
+        pv = PValues(vals)
+
+        # basic vector functionality
+        @test values(pv) === vals
+        @test sum(pv) == sum(vals)
+        @test length(pv) == n
+        @test ones(pv) == ones(eltype(vals), n)
+        @test minimum(pv) == minimum(vals)
+        @test maximum(pv) == maximum(vals)
+        @test extrema(pv) == extrema(vals)
+        @test [x for x in pv] == vals
+
+        pvt = PValues(vals, 0.0, 1.0)
+        @test minimum(pvt) == 0.0
+        @test maximum(pvt) == 1.0
+
+        for T in (Float16, Float32, Float64)
+            vals = rand(T, n)
+            pv = PValues(vals)
+            @test eltype(pv) == T
+            @test eltype(values(pv)) == T
+        end
+
+        @test_throws DomainError PValues([0.1, 0.2, 2.0])
+        @test_throws DomainError PValues([0.1, 0.2, -2.0])
+
+    end
+
+end
+
+end

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -47,6 +47,11 @@ using Base.Test
         @test_throws DomainError PValues([0.1, 0.2, 2.0])
         @test_throws DomainError PValues([0.1, 0.2, -2.0])
 
+        # TODO discuss expected behaviour in edge cases
+        @test_throws MethodError PValues(0.5)
+        @test_throws ArgumentError PValues([])
+        @test_throws TypeError PValues([0, 1])
+
     end
 
 end

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -14,7 +14,7 @@ using Base.Test
         pv = PValues(vals)
 
         # basic vector functionality
-        @test values(pv) === vals
+        @test values(pv) ≡ vals
         @test sum(pv) == sum(vals)
         @test length(pv) == n
         @test ones(pv) == ones(eltype(vals), n)
@@ -26,6 +26,8 @@ using Base.Test
         pvt = PValues(vals, 0.0, 1.0)
         @test minimum(pvt) == 0.0
         @test maximum(pvt) == 1.0
+
+        @test convert(PValues, vals) == PValues(vals)
 
         for T in (Float16, Float32, Float64)
             vals = rand(T, n)

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -22,13 +22,17 @@ using Base.Test
         @test maximum(pv) == maximum(vals)
         @test extrema(pv) == extrema(vals)
         @test [x for x in pv] == vals
+        @test convert(PValues, vals) == PValues(vals)
 
-        pvt = PValues(vals, 0.0, 1.0)
+        # min/max are taken from the type fields,
+        # not recomputed from the values
+        pvt = PValues(vals)
+        pvt.min = 0.0
+        pvt.max = 1.0
         @test minimum(pvt) == 0.0
         @test maximum(pvt) == 1.0
 
-        @test convert(PValues, vals) == PValues(vals)
-
+        # parametric type that keeps input float type
         for T in (Float16, Float32, Float64)
             vals = rand(T, n)
             pv = PValues(vals)
@@ -36,6 +40,10 @@ using Base.Test
             @test eltype(values(pv)) == T
         end
 
+        # min/max cannot be passed to constructor
+        @test_throws MethodError PValues(vals, 0.0, 1.0)
+
+        # invalid p-values are caught
         @test_throws DomainError PValues([0.1, 0.2, 2.0])
         @test_throws DomainError PValues([0.1, 0.2, -2.0])
 

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -22,22 +22,22 @@ using Base.Test
     end
 
 
-    @testset "validPValues" begin
+    @testset "valid_pvalues" begin
 
-        validPValues = MultipleTesting.validPValues
+        valid_pvalues = MultipleTesting.valid_pvalues
 
         # test against invalid vector inputs
-        @test_throws DomainError validPValues([-1.])
-        @test_throws DomainError validPValues([2.])
-        @test_throws DomainError validPValues([0.1, 0.2, 1.2])
-        @test_throws DomainError validPValues([0.1, -0.3, 0.2])
+        @test_throws DomainError valid_pvalues([-1.])
+        @test_throws DomainError valid_pvalues([2.])
+        @test_throws DomainError valid_pvalues([0.1, 0.2, 1.2])
+        @test_throws DomainError valid_pvalues([0.1, -0.3, 0.2])
 
         # test against valid vector inputs
-        @test validPValues([0.0]) == nothing
-        @test validPValues([1.0]) == nothing
-        @test validPValues(rand(1)) == nothing
-        @test validPValues([0.1, 0.2, 0.9]) == nothing
-        @test validPValues(rand(5)) == nothing
+        @test valid_pvalues([0.0]) == nothing
+        @test valid_pvalues([1.0]) == nothing
+        @test valid_pvalues(rand(1)) == nothing
+        @test valid_pvalues([0.1, 0.2, 0.9]) == nothing
+        @test valid_pvalues(rand(5)) == nothing
 
     end
 


### PR DESCRIPTION
Adds the `PValues` type that represents a vector of p-values. Benefits of working with this specialised type instead with a simple vector of floats:
- More meaningful dispatch, especially when a method can work with different inputs (e.g. p-values vs z-scores)
- Validity checking is integrated into the constructor, instead of having to use a separate function explicitly
- Properties of the p-values have to be computed only once: minimum and maximum; these are part of the validity check anyway
- The type is based on the `AbstractVector`, and hence all vector operations work naturally without the need to redefine standard methods

Uses the `PValues` type for all relevant methods. A fallback for p-values in the form of a vector of floats ensures backwards compatibility.

Examples:
```julia
v = [0.001, 0.01, 0.1, 0.5]

## new features
pv = PValues(v)
extrema(pv)  # no recomputation needed
adjust(pv, Sidak())
estimate_pi0(pv, Storey())

## old behaviour
adjust(v, Sidak())
estimate_pi0(v, Storey())
```