### PR TITLE
ZScores type

### DIFF
--- a/src/MultipleTesting.jl
+++ b/src/MultipleTesting.jl
@@ -55,7 +55,12 @@ export
     WilkinsonCombination,
     MinimumCombination,
     PValues,
-    ZScores
+    ZScores,
+    Alternative,
+    Lower,
+    Upper,
+    Both,
+    transform
 
 
 include("types.jl")

--- a/src/MultipleTesting.jl
+++ b/src/MultipleTesting.jl
@@ -53,7 +53,9 @@ export
     TippettCombination,
     SimesCombination,
     WilkinsonCombination,
-    MinimumCombination
+    MinimumCombination,
+    PValues,
+    ZScores
 
 
 include("types.jl")

--- a/src/types.jl
+++ b/src/types.jl
@@ -74,38 +74,36 @@ immutable Both  <: Alternative end
 
 # PValues to ZScores
 
-function transform(::Type{PValues}, zs::ZScores, alternative::Type{Lower})
+function PValues(zs::ZScores, alternative::Type{Lower})
     p = cdf(Normal(), zs)
     return PValues(p)
 end
 
-function transform(::Type{PValues}, zs::ZScores, alternative::Type{Upper})
+function PValues(zs::ZScores, alternative::Type{Upper})
     p = ccdf(Normal(), zs)
     return PValues(p)
 end
 
-function transform(::Type{PValues}, zs::ZScores, alternative::Type{Both})
+function PValues(zs::ZScores, alternative::Type{Both})
     p = 2 * min( ccdf(Normal(), zs), cdf(Normal(), zs) )
     return PValues(p)
 end
 
-transform(pv::Type{PValues}, zs::ZScores) = transform(pv, zs, Both)
+PValues(zs::ZScores) = PValues(zs, Both)
 
-transform(T::Type{PValues}, zs::ZScores, alt::Alternative) =
-    transform(T, zs, typeof(alt))
+PValues(zs::ZScores, alt::Alternative) = PValues(zs, typeof(alt))
 
 
 # ZScores to PValues
 
-function transform(::Type{ZScores}, pv::PValues, alternative::Type{Upper})
+function ZScores(pv::PValues, alternative::Type{Upper})
     z = cquantile(Normal(), pv)
     return ZScores(z)
 end
 
-function transform(::Type{ZScores}, pv::PValues, alternative::Type{Lower})
+function ZScores(pv::PValues, alternative::Type{Lower})
     z = quantile(Normal(), pv)
     return ZScores(z)
 end
 
-transform(T::Type{ZScores}, pv::PValues, alt::Alternative) =
-    transform(T, pv, typeof(alt))
+ZScores(pv::PValues, alt::Alternative) = ZScores(pv, typeof(alt))

--- a/src/types.jl
+++ b/src/types.jl
@@ -8,7 +8,7 @@ abstract type PValueAdjustment end
 
 abstract type PValueCombination end
 
-abstract Alternative
+abstract type Alternative end
 
 
 ## concrete types ##
@@ -57,7 +57,7 @@ end
 Base.convert{T<:AbstractFloat}(::Type{ZScores}, x::AbstractVector{T}) = ZScores(x)
 
 Base.size(zs::ZScores) = (length(zs.values), )
-Base.linearindexing{T<:ZScores}(::Type{T}) = Base.LinearFast()
+Base.IndexStyle{T<:ZScores}(::Type{T}) = IndexLinear()
 Base.getindex(zs::ZScores, i::Int) = zs.values[i]
 
 Base.values(zs::ZScores) = zs.values
@@ -75,17 +75,17 @@ immutable Both  <: Alternative end
 # PValues to ZScores
 
 function PValues(zs::ZScores, alternative::Type{Lower})
-    p = cdf(Normal(), zs)
+    p = cdf.(Normal(), zs)
     return PValues(p)
 end
 
 function PValues(zs::ZScores, alternative::Type{Upper})
-    p = ccdf(Normal(), zs)
+    p = ccdf.(Normal(), zs)
     return PValues(p)
 end
 
 function PValues(zs::ZScores, alternative::Type{Both})
-    p = 2 * min( ccdf(Normal(), zs), cdf(Normal(), zs) )
+    p = 2 * min.( ccdf.(Normal(), zs), cdf.(Normal(), zs) )
     return PValues(p)
 end
 
@@ -97,12 +97,12 @@ PValues(zs::ZScores, alt::Alternative) = PValues(zs, typeof(alt))
 # ZScores to PValues
 
 function ZScores(pv::PValues, alternative::Type{Upper})
-    z = cquantile(Normal(), pv)
+    z = cquantile.(Normal(), pv)
     return ZScores(z)
 end
 
 function ZScores(pv::PValues, alternative::Type{Lower})
-    z = quantile(Normal(), pv)
+    z = quantile.(Normal(), pv)
     return ZScores(z)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -46,6 +46,10 @@ Base.length(pv::PValues) = length(pv.values)
 
 type ZScores{T<:AbstractFloat} <: AbstractVector{T}
     values::AbstractVector{T}
+
+    function(::Type{ZScores}){T}(values::AbstractVector{T})
+        new{T}(values)
+    end
 end
 
 Base.convert{T<:AbstractFloat}(::Type{ZScores}, x::AbstractVector{T}) = ZScores(x)

--- a/src/types.jl
+++ b/src/types.jl
@@ -40,3 +40,18 @@ Base.minimum(pv::PValues) = pv.min
 Base.maximum(pv::PValues) = pv.max
 Base.extrema(pv::PValues) = (minimum(pv), maximum(pv))
 Base.length(pv::PValues) = length(pv.values)
+
+
+## ZScores
+
+type ZScores{T<:AbstractFloat} <: AbstractVector{T}
+    values::AbstractVector{T}
+end
+
+Base.convert{T<:AbstractFloat}(::Type{ZScores}, x::AbstractVector{T}) = ZScores(x)
+
+Base.size(zs::ZScores) = (length(zs.values), )
+Base.linearindexing{T<:ZScores}(::Type{T}) = Base.LinearFast()
+Base.getindex(zs::ZScores, i::Int) = zs.values[i]
+
+Base.values(zs::ZScores) = zs.values

--- a/src/types.jl
+++ b/src/types.jl
@@ -63,8 +63,6 @@ Base.getindex(zs::ZScores, i::Int) = zs.values[i]
 Base.values(zs::ZScores) = zs.values
 
 
-# transformation between PValues and ZScores
-
 immutable Upper <: Alternative end
 
 immutable Lower <: Alternative end
@@ -72,7 +70,7 @@ immutable Lower <: Alternative end
 immutable Both  <: Alternative end
 
 
-# PValues to ZScores
+# ZScores to PValues
 
 function PValues(zs::ZScores, alternative::Type{Lower})
     p = cdf.(Normal(), zs)
@@ -94,7 +92,7 @@ PValues(zs::ZScores) = PValues(zs, Both)
 PValues(zs::ZScores, alt::Alternative) = PValues(zs, typeof(alt))
 
 
-# ZScores to PValues
+# PValues to ZScores
 
 function ZScores(pv::PValues, alternative::Type{Upper})
     z = cquantile.(Normal(), pv)

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -112,6 +112,48 @@ using Base.Test
 
     end
 
+
+    @testset "PValues - ZScores transformations" begin
+
+        z = [0.0, 1.0, -1.0, 2.0, -2.0, 3.0, -3.0]
+        pu = [0.5, 0.15866, 0.84135, 0.02275, 0.97725, 0.00135, 0.99865]
+
+        zs = ZScores(z)
+        pv = PValues(pu)
+
+        p1 = transform(PValues, zs, Upper)
+        @test typeof(p1) <: PValues
+        @test isapprox( p1, pu, atol = 1e-5  )
+        z1 = transform(ZScores, p1, Upper)
+        @test typeof(z1) <: ZScores
+        @test isapprox( z1, z )
+
+        p1 = transform(PValues, zs, Lower)
+        @test typeof(p1) <: PValues
+        @test isapprox( p1, 1-pu, atol = 1e-5  )
+        z1 = transform(ZScores, p1, Lower)
+        @test typeof(z1) <: ZScores
+        @test isapprox( z1, z )
+
+        p1 = transform(PValues, zs, Both)
+        @test typeof(p1) <: PValues
+        @test isapprox( p1, 2*min(pu, 1-pu), atol = 1e-4 )
+        # no transformation since sign of z-scores is unknown
+        @test_throws MethodError transform(ZScores, p1, Both)
+
+        # defaults and alternatives
+        @test transform(PValues, zs, Both) == transform(PValues, zs)
+        @test transform(PValues, zs, Both) == transform(PValues, zs, Both())
+        @test transform(ZScores, pv, Lower) == transform(ZScores, pv, Lower())
+
+        # only meaningful transformations
+        @test_throws MethodError transform(ZScores, zs)
+        @test_throws MethodError transform(ZScores, zs, Lower)
+        @test_throws MethodError transform(PValues, pv)
+        @test_throws MethodError transform(PValues, pv, Lower)
+
+    end
+
 end
 
 end

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -75,6 +75,41 @@ using Base.Test
 
     end
 
+
+    @testset "ZScores type" begin
+
+        n = 10
+        vals = randn(n)
+
+        zs = ZScores(vals)
+
+        # basic vector functionality
+        @test values(zs) ≡ vals
+        @test sum(zs) == sum(vals)
+        @test length(zs) == n
+        @test ones(zs) == ones(eltype(vals), n)
+        @test minimum(zs) == minimum(vals)
+        @test maximum(zs) == maximum(vals)
+        @test extrema(zs) == extrema(vals)
+        @test [x for x in zs] == vals
+        @test convert(ZScores, vals) == ZScores(vals)
+
+        # parametric type that keeps input float type
+        for T in (Float16, Float32, Float64)
+            vals = randn(T, n)
+            zs = ZScores(vals)
+            @test eltype(zs) == T
+            @test eltype(values(zs)) == T
+        end
+
+        # TODO discuss expected behaviour in edge cases
+        @test_throws MethodError ZScores(0.1)
+        # differ from PValues behaviour
+        @test_throws MethodError ZScores([])
+        @test_throws MethodError ZScores(rand(Int, n))
+
+    end
+
 end
 
 end

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -121,36 +121,38 @@ using Base.Test
         zs = ZScores(z)
         pv = PValues(pu)
 
-        p1 = transform(PValues, zs, Upper)
+        p1 = PValues(zs, Upper)
         @test typeof(p1) <: PValues
         @test isapprox( p1, pu, atol = 1e-5  )
-        z1 = transform(ZScores, p1, Upper)
+        z1 = ZScores(p1, Upper)
         @test typeof(z1) <: ZScores
         @test isapprox( z1, z )
 
-        p1 = transform(PValues, zs, Lower)
+        p1 = PValues(zs, Lower)
         @test typeof(p1) <: PValues
         @test isapprox( p1, 1-pu, atol = 1e-5  )
-        z1 = transform(ZScores, p1, Lower)
+        z1 = ZScores(p1, Lower)
         @test typeof(z1) <: ZScores
         @test isapprox( z1, z )
 
-        p1 = transform(PValues, zs, Both)
+        p1 = PValues(zs, Both)
         @test typeof(p1) <: PValues
         @test isapprox( p1, 2*min(pu, 1-pu), atol = 1e-4 )
         # no transformation since sign of z-scores is unknown
-        @test_throws MethodError transform(ZScores, p1, Both)
+        @test_throws MethodError ZScores(p1, Both)
 
         # defaults and alternatives
-        @test transform(PValues, zs, Both) == transform(PValues, zs)
-        @test transform(PValues, zs, Both) == transform(PValues, zs, Both())
-        @test transform(ZScores, pv, Lower) == transform(ZScores, pv, Lower())
+        @test PValues(zs, Both) == PValues(zs)
+        @test PValues(zs, Both) == PValues(zs, Both())
+        @test ZScores(pv, Lower) == ZScores(pv, Lower())
 
         # only meaningful transformations
-        @test_throws MethodError transform(ZScores, zs)
-        @test_throws MethodError transform(ZScores, zs, Lower)
-        @test_throws MethodError transform(PValues, pv)
-        @test_throws MethodError transform(PValues, pv, Lower)
+        @test_throws MethodError ZScores(zs, Lower)
+        @test_throws MethodError PValues(pv, Lower)
+
+        # TODO define desired behaviour
+        @test ZScores(zs) == zs
+        @test PValues(pv) == pv
 
     end
 

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -137,7 +137,7 @@ using Base.Test
 
         p1 = PValues(zs, Both)
         @test typeof(p1) <: PValues
-        @test isapprox( p1, 2*min(pu, 1-pu), atol = 1e-4 )
+        @test isapprox( p1, 2*min.(pu, 1-pu), atol = 1e-4 )
         # no transformation since sign of z-scores is unknown
         @test_throws MethodError ZScores(p1, Both)
 

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -47,8 +47,9 @@ using Base.Test
 
         # TODO discuss expected behaviour in edge cases
         @test_throws MethodError PValues(0.5)
-        @test_throws ArgumentError PValues([])
         @test_throws TypeError PValues([0, 1])
+        @test_throws ArgumentError PValues([]) # Any
+        @test_throws ArgumentError PValues(Float64[]) # Float
 
     end
 
@@ -103,10 +104,11 @@ using Base.Test
         end
 
         # TODO discuss expected behaviour in edge cases
-        @test_throws MethodError ZScores(0.1)
-        # differ from PValues behaviour
-        @test_throws MethodError ZScores([])
-        @test_throws MethodError ZScores(rand(Int, n))
+        @test_throws MethodError ZScores(0.5)
+        @test_throws TypeError ZScores([0, 1])
+        # differences from PValues behaviour
+        @test_throws TypeError ZScores([]) # Any
+        @test isa( ZScores(Float64[]), ZScores ) # Float
 
     end
 


### PR DESCRIPTION
Specialised abstract vector type to represent z-scores, analogous to the `PValues` type.