### PR TITLE
Specify total number of tests for p-value adjustment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ adjust(pvals, Sidak())
 adjust(pvals, ForwardStop())
 ```
 
+The adjustment can also be performed on the `k` smallest out of `n` p-values:
+
+```julia
+adjust(pvals, n, PValueAdjustmentMethod)
+```
+
 
 ### Estimation of π₀
 

--- a/src/pval-adjustment.jl
+++ b/src/pval-adjustment.jl
@@ -203,3 +203,32 @@ function forwardstop(pvalues::PValues)
 end
 
 forwardstop_multiplier(i::Int, n::Int) = 1/(n-i)
+
+
+## internal ##
+
+# step-up / step-down
+
+function stepup!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, multiplier::Function, n::Integer = length(sortedPValues))
+    sortedPValues[n] *= multiplier(0, n)
+    for i in 1:(n-1)
+        sortedPValues[n-i] = min(sortedPValues[n-i+1], sortedPValues[n-i] * multiplier(i, n))
+    end
+    return sortedPValues
+end
+
+
+function stepdown!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, multiplier::Function, n::Integer = length(sortedPValues))
+  stepfun(p::T, i::Int, n::Int) = p * multiplier(i, n)
+  general_stepdown!(sortedPValues, stepfun, n)
+  return sortedPValues
+end
+
+
+function general_stepdown!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, stepfun::Function, n::Integer = length(sortedPValues))
+    sortedPValues[1] = stepfun(sortedPValues[1], 1, n)
+    for i in 2:n
+        sortedPValues[i] = max(sortedPValues[i-1], stepfun(sortedPValues[i], i, n))
+    end
+    return sortedPValues
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,28 +1,5 @@
 ## utility functions ##
 
-function stepup!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, multiplier::Function, n::Integer = length(sortedPValues))
-    sortedPValues[n] *= multiplier(0, n)
-    for i in 1:(n-1)
-        sortedPValues[n-i] = min(sortedPValues[n-i+1], sortedPValues[n-i] * multiplier(i, n))
-    end
-    return sortedPValues
-end
-
-# multiplier stepdown
-function stepdown!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, multiplier::Function, n::Integer = length(sortedPValues))
-  stepfun(p::T, i::Int, n::Int) = p * multiplier(i, n)
-  general_stepdown!(sortedPValues, stepfun, n)
-  return sortedPValues
-end
-
-function general_stepdown!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, stepfun::Function, n::Integer = length(sortedPValues))
-    sortedPValues[1] = stepfun(sortedPValues[1], 1, n)
-    for i in 2:n
-        sortedPValues[i] = max(sortedPValues[i-1], stepfun(sortedPValues[i], i, n))
-    end
-    return sortedPValues
-end
-
 function reorder{T<:Real}(values::AbstractVector{T})
     newOrder = sortperm(values)
     oldOrder = sortperm(newOrder)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,6 +24,15 @@ function sort_if_needed!(x; kws...)
 end
 
 
+function unsort(x; kws...)
+    y = copy(x)
+    while issorted(y; kws...)
+        sample!(x, y, replace = false)
+    end
+    return y
+end
+
+
 function valid_pvalues{T<:AbstractFloat}(x::AbstractVector{T})
     if !isin(x)
         throw(DomainError())

--- a/test/test-pi0-estimators.jl
+++ b/test/test-pi0-estimators.jl
@@ -15,13 +15,7 @@ using StatsBase
 
     lambdas = collect(0.05:0.05:0.95)
 
-    function unsort(x)
-        y = copy(x)
-        while issorted(y)
-            sample!(x, y, replace = false)
-        end
-        return y
-    end
+    unsort = MultipleTesting.unsort
 
 
     @testset "Storey π0" begin

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -77,6 +77,32 @@ using Base.Test
 
     end
 
+
+    @testset "unsort" begin
+
+        n = 20
+        xs = sort(rand(n))
+        xr = reverse(xs) # reverse sorted
+        xu = xs[[1:2:n-1; 2:2:n]] # unsorted
+        @test !issorted(xu)
+
+        unsort = MultipleTesting.unsort
+
+        @test issorted(xs)
+        @test !issorted(unsort(xs))
+
+        # unsorted input gets returned unchanged
+        @test unsort(xu) == xu
+
+        # `sort` keywords work
+        @test !issorted(xr)
+        @test issorted(xr, rev = true)
+        @test issorted(unsort(xr), rev = true)
+        @test !issorted(unsort(xr, rev = true), rev = true)
+
+    end
+
+
 end
 
 end


### PR DESCRIPTION
Implements the option to specify the total number of tests for p-value adjustments, as discussed in #30:
> As a side note that's also another feature we could add, i.e. also allow m as function input similar to p.adjust for cases where only part of the p-values (say the ones below 0.001) are available.:

For supported methods, this offers the new interface:
```julia
adjust(pValues, n::Integer, PValueAdjustmentMethod)
```