### PR TITLE
Better names for types

### DIFF
--- a/src/MultipleTesting.jl
+++ b/src/MultipleTesting.jl
@@ -16,7 +16,7 @@ using Distributions
 export
     PValues,
     adjust,
-    PValueAdjustmentMethod,
+    PValueAdjustment,
     Bonferroni,
     BenjaminiHochberg,
     BenjaminiHochbergAdaptive,
@@ -44,7 +44,7 @@ export
     isin,
     fit,
     BetaUniformMixtureModel,
-    PValueCombinationMethod,
+    PValueCombination,
     combine,
     FisherCombination,
     LogitCombination,

--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -1,15 +1,15 @@
 ### Combination methods for p-values ###
 
-combine{T<:AbstractFloat, M<:PValueCombinationMethod}(pValues::AbstractVector{T}, method::M) = combine(PValues(pValues), method)
+combine{T<:AbstractFloat, M<:PValueCombination}(pValues::AbstractVector{T}, method::M) = combine(PValues(pValues), method)
 
-combine{T<:AbstractFloat, M<:PValueCombinationMethod}(pValues::AbstractVector{T}, weights::WeightVec, method::M) = combine(PValues(pValues), weights, method)
+combine{T<:AbstractFloat, M<:PValueCombination}(pValues::AbstractVector{T}, weights::WeightVec, method::M) = combine(PValues(pValues), weights, method)
 
-combine{T<:AbstractFloat, R<:Real, M<:PValueCombinationMethod}(pValues::AbstractVector{T}, weights::AbstractVector{R}, method::M) = combine(PValues(pValues), weights, method)
+combine{T<:AbstractFloat, R<:Real, M<:PValueCombination}(pValues::AbstractVector{T}, weights::AbstractVector{R}, method::M) = combine(PValues(pValues), weights, method)
 
 
 ## Fisher combination ##
 
-immutable FisherCombination <: PValueCombinationMethod
+immutable FisherCombination <: PValueCombination
 end
 
 function combine{T<:AbstractFloat}(pValues::PValues{T}, method::FisherCombination)
@@ -32,7 +32,7 @@ end
 
 ## Logit combination ##
 
-immutable LogitCombination <: PValueCombinationMethod
+immutable LogitCombination <: PValueCombination
 end
 
 function combine{T<:AbstractFloat}(pValues::PValues{T}, method::LogitCombination)
@@ -57,7 +57,7 @@ end
 
 ## Stouffer combination ##
 
-immutable StoufferCombination <: PValueCombinationMethod
+immutable StoufferCombination <: PValueCombination
 end
 
 function combine{T<:AbstractFloat}(pValues::PValues{T}, method::StoufferCombination)
@@ -105,7 +105,7 @@ end
 
 ## Tippett combination ##
 
-immutable TippettCombination <: PValueCombinationMethod
+immutable TippettCombination <: PValueCombination
 end
 
 function combine{T<:AbstractFloat}(pValues::PValues{T}, method::TippettCombination)
@@ -124,7 +124,7 @@ end
 
 ## Simes combination ##
 
-immutable SimesCombination <: PValueCombinationMethod
+immutable SimesCombination <: PValueCombination
 end
 
 function combine{T<:AbstractFloat}(pValues::PValues{T}, method::SimesCombination)
@@ -144,7 +144,7 @@ end
 
 ## Wilkinson combination ##
 
-immutable WilkinsonCombination <: PValueCombinationMethod
+immutable WilkinsonCombination <: PValueCombination
     rank::Int
 
     function WilkinsonCombination(rank)
@@ -175,15 +175,15 @@ end
 
 ## Generalised minimum combination ##
 
-immutable MinimumCombination <: PValueCombinationMethod
-    method::PValueAdjustmentMethod
+immutable MinimumCombination <: PValueCombination
+    method::PValueAdjustment
 end
 
 function combine{T<:AbstractFloat}(pValues::PValues{T}, method::MinimumCombination)
     minimum_combination(pValues, method.method)
 end
 
-function minimum_combination{T<:AbstractFloat}(pValues::PValues{T}, pAdjustMethod::PValueAdjustmentMethod)
+function minimum_combination{T<:AbstractFloat}(pValues::PValues{T}, pAdjustMethod::PValueAdjustment)
     n = length(pValues)
     if n == 1
         return pValues[1]

--- a/src/pi0-estimators.jl
+++ b/src/pi0-estimators.jl
@@ -157,7 +157,7 @@ Reference: Benjamini, Krieger and Yekutieli, 2006
 """
 immutable TwoStep <: Pi0Estimator
     α::AbstractFloat
-    method::PValueAdjustmentMethod
+    method::PValueAdjustment
 
     TwoStep(α, method) = isin(α, 0., 1.) ? new(α, method) : throw(DomainError())
 end
@@ -170,7 +170,7 @@ function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::TwoSt
     twostep_pi0(pValues, pi0estimator.α, pi0estimator.method)
 end
 
-function twostep_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, alpha::T, method::PValueAdjustmentMethod)
+function twostep_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, alpha::T, method::PValueAdjustment)
     padj = adjust(pValues, method)
     pi0 = sum(padj .>= (alpha/(1+alpha))) / length(padj)
     return(pi0)

--- a/src/pval-adjustment.jl
+++ b/src/pval-adjustment.jl
@@ -2,14 +2,14 @@
 
 # promotion from float vectors to PValues type
 
-adjust{T<:AbstractFloat, M<:PValueAdjustmentMethod}(pvals::Vector{T}, method::M) = adjust(PValues(pvals), method)
+adjust{T<:AbstractFloat, M<:PValueAdjustment}(pvals::Vector{T}, method::M) = adjust(PValues(pvals), method)
 
-adjust{T<:AbstractFloat, M<:PValueAdjustmentMethod}(pvals::Vector{T}, n::Int, method::M) = adjust(PValues(pvals), n, method)
+adjust{T<:AbstractFloat, M<:PValueAdjustment}(pvals::Vector{T}, n::Int, method::M) = adjust(PValues(pvals), n, method)
 
 
 # Bonferroni
 
-immutable Bonferroni <: PValueAdjustmentMethod
+immutable Bonferroni <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::Bonferroni) = adjust(pvals, length(pvals), method)
@@ -25,7 +25,7 @@ end
 
 # Benjamini-Hochberg
 
-immutable BenjaminiHochberg <: PValueAdjustmentMethod
+immutable BenjaminiHochberg <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::BenjaminiHochberg) = adjust(pvals, length(pvals), method)
@@ -49,7 +49,7 @@ bejamini_hochberg_multiplier(i::Int, k::Int, n::Int) = n/(k-i)
 
 # Benjamini-Hochberg Adaptive
 
-immutable BenjaminiHochbergAdaptive <: PValueAdjustmentMethod
+immutable BenjaminiHochbergAdaptive <: PValueAdjustment
     pi0estimator::Pi0Estimator
 end
 
@@ -68,7 +68,7 @@ end
 
 # Benjamini-Yekutieli
 
-immutable BenjaminiYekutieli <: PValueAdjustmentMethod
+immutable BenjaminiYekutieli <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::BenjaminiYekutieli) = adjust(pvals, length(pvals), method)
@@ -92,7 +92,7 @@ benjamini_yekutieli_multiplier(i::Int, k::Int, n::Int) = sum(1./(1:n))*n/(k-i)
 
 # Benjamini-Liu
 
-immutable BenjaminiLiu <: PValueAdjustmentMethod
+immutable BenjaminiLiu <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::BenjaminiLiu) = adjust(pvals, length(pvals), method)
@@ -121,7 +121,7 @@ end
 
 # Hochberg
 
-immutable Hochberg <: PValueAdjustmentMethod
+immutable Hochberg <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::Hochberg) = adjust(pvals, length(pvals), method)
@@ -145,7 +145,7 @@ hochberg_multiplier(i::Int, k::Int, n::Int) = n-k+i+1
 
 # Holm
 
-immutable Holm <: PValueAdjustmentMethod
+immutable Holm <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::Holm) = adjust(pvals, length(pvals), method)
@@ -169,7 +169,7 @@ holm_multiplier(i::Int, n::Int) = n-i+1
 
 # Hommel
 
-immutable Hommel <: PValueAdjustmentMethod
+immutable Hommel <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::Hommel) = adjust(pvals, length(pvals), method)
@@ -201,7 +201,7 @@ end
 
 # Sidak
 
-immutable Sidak <: PValueAdjustmentMethod
+immutable Sidak <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::Sidak) = adjust(pvals, length(pvals), method)
@@ -216,7 +216,7 @@ end
 
 # Forward Stop
 
-immutable ForwardStop <: PValueAdjustmentMethod
+immutable ForwardStop <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::ForwardStop) = adjust(pvals, length(pvals), method)

--- a/src/types.jl
+++ b/src/types.jl
@@ -4,10 +4,10 @@ abstract Pi0Estimator
 
 abstract Pi0Fit
 
-abstract PValueAdjustmentMethod
+abstract PValueAdjustment
 
 # consistent naming
-abstract PValueCombinationMethod
+abstract PValueCombination
 
 
 ## concrete types ##

--- a/test/test-combinations.jl
+++ b/test/test-combinations.jl
@@ -46,8 +46,8 @@ using Base.Test
 
     @testset "$(method)" for method in keys(ref2)
 
-        @test issubtype(method, PValueCombinationMethod)
-        @test issubtype(typeof(method()), PValueCombinationMethod)
+        @test issubtype(method, PValueCombination)
+        @test issubtype(typeof(method()), PValueCombination)
 
         ref = ref1[method]
         @test isapprox( combine(PValues(p1), method()), ref, atol = 1e-8)
@@ -75,7 +75,7 @@ using Base.Test
         @test_throws MethodError WilkinsonCombination()  # TODO default value
         @test_throws ArgumentError WilkinsonCombination(0)
 
-        @test issubtype(typeof(method), PValueCombinationMethod)
+        @test issubtype(typeof(method), PValueCombination)
 
         # Wilkinson with rank = 1 is Tippett's method
         ref = ref1[TippettCombination]
@@ -117,7 +117,7 @@ using Base.Test
 
         padj_comb = MinimumCombination( p_adjustment() )
 
-        @test issubtype(typeof(padj_comb), PValueCombinationMethod)
+        @test issubtype(typeof(padj_comb), PValueCombination)
 
         @test isapprox( combine(PValues(p1), padj_comb), ref1[p_combination], atol = 1e-8)
         @test isapprox( combine(p1, padj_comb), ref1[p_combination], atol = 1e-8)

--- a/test/test-pval-adjustment.jl
+++ b/test/test-pval-adjustment.jl
@@ -46,8 +46,8 @@ using Base.Test
 
     @testset "pvalue adjustment $method" for method in keys(ref1)
 
-        @test issubtype(method, PValueAdjustmentMethod)
-        @test issubtype(typeof(method()), PValueAdjustmentMethod)
+        @test issubtype(method, PValueAdjustment)
+        @test issubtype(typeof(method()), PValueAdjustment)
 
         @test_throws MethodError method(0.1)
 


### PR DESCRIPTION
Avoid calling abstract types 'method', which is rather confusing, and rename
them for better consistency and understanding:
- `PValueAdjustmentMethod` -> `PValueAdjustment`
- `PValueCombinationMethod` -> `PValueCombination`