### PR TITLE
Simplify signature definition for scalar floats

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -31,7 +31,7 @@ cdf(bum, 0:0.05:1)
 """
 function BetaUniformMixtureModel end
 
-function BetaUniformMixtureModel{T<:AbstractFloat}(π0::T, α::T = 0.5, β::T = 1.0)
+function BetaUniformMixtureModel(π0::AbstractFloat, α::AbstractFloat = 0.5, β::AbstractFloat = 1.0)
     if !isin(π0, 0., 1.)
         throw(DomainError())
     end

--- a/src/pi0-estimators.jl
+++ b/src/pi0-estimators.jl
@@ -37,7 +37,7 @@ function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::Store
     storey_pi0(pValues, pi0estimator.λ)
 end
 
-function storey_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, lambda::T)
+function storey_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, lambda::AbstractFloat)
     pi0 = (sum(pValues .>= lambda) / length(pValues)) / (1.-lambda)
     pi0 = min(pi0, 1.)
     return pi0
@@ -170,7 +170,7 @@ function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::TwoSt
     twostep_pi0(pValues, pi0estimator.α, pi0estimator.method)
 end
 
-function twostep_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, alpha::T, method::PValueAdjustmentMethod)
+function twostep_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, alpha::AbstractFloat, method::PValueAdjustmentMethod)
     padj = adjust(pValues, method)
     pi0 = sum(padj .>= (alpha/(1+alpha))) / length(padj)
     return(pi0)
@@ -261,8 +261,9 @@ function estimate_pi0(pi0fit::CensoredBUMFit)
     return π0
 end
 
-function cbum_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, γ0::T = 0.5, λ::T = 0.05,
-                                    xtol::T = 1e-6, maxiter::Int = 10000)
+function cbum_pi0{T<:AbstractFloat}(pValues::AbstractVector{T},
+                                    γ0::AbstractFloat = 0.5, λ::AbstractFloat = 0.05,
+                                    xtol::AbstractFloat = 1e-6, maxiter::Int = 10000)
     n = length(pValues)
     idx_right = pValues .>= λ
     n2 = sum(idx_right)
@@ -297,8 +298,9 @@ function cbum_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, γ0::T = 0.5, λ
     return NaN, [γ, α], false
 end
 
-function cbum_pi0_naive{T<:AbstractFloat}(pValues::AbstractVector{T}, γ0::T = 0.5, λ::T = 0.05,
-                        xtol::T = 1e-6, maxiter::Int = 10000)
+function cbum_pi0_naive{T<:AbstractFloat}(pValues::AbstractVector{T},
+                                          γ0::AbstractFloat = 0.5, λ::AbstractFloat = 0.05,
+                                          xtol::AbstractFloat = 1e-6, maxiter::Int = 10000)
     n = length(pValues)
     z = fill(1-γ0, n)
     idx_left = pValues .< λ

--- a/src/pval-adjustment.jl
+++ b/src/pval-adjustment.jl
@@ -54,7 +54,7 @@ immutable BenjaminiHochbergAdaptive <: PValueAdjustmentMethod
 end
 
 ## default to BenjaminiHochberg
-BenjaminiHochbergAdaptive{T<:AbstractFloat}(π0::T) = BenjaminiHochbergAdaptive(Oracle(π0))
+BenjaminiHochbergAdaptive(π0::AbstractFloat) = BenjaminiHochbergAdaptive(Oracle(π0))
 
 BenjaminiHochbergAdaptive() = BenjaminiHochbergAdaptive(1.0)
 
@@ -111,7 +111,7 @@ function benjamini_liu(pValues::PValues, n::Integer)
     return min(sortedPValues[originalOrder], 1)
 end
 
-function benjamini_liu_step{T<:AbstractFloat}(p::T, i::Int, n::Int)
+function benjamini_liu_step(p::AbstractFloat, i::Int, n::Int)
     # a bit more involved because cutoffs at significance α have the form:
     # P_(i) <= 1- [1 - min(1, m/(m-i+1)α)]^{1/(m-i+1)}
     s = n-i+1
@@ -248,7 +248,7 @@ end
 
 
 function stepdown!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, multiplier::Function, k::Integer, n::Integer)
-  stepfun(p::T, i::Int, n::Int) = p * multiplier(i, n)
+  stepfun(p::AbstractFloat, i::Int, n::Int) = p * multiplier(i, n)
   general_stepdown!(sortedPValues, stepfun, k, n)
   return sortedPValues
 end

--- a/src/qvalue.jl
+++ b/src/qvalue.jl
@@ -1,6 +1,6 @@
 ## qValues ##
 
-function qValues{T<:AbstractFloat}(pValues::AbstractVector{T}, pi0::T, pfdr::Bool = false)
+function qValues{T<:AbstractFloat}(pValues::AbstractVector{T}, pi0::AbstractFloat, pfdr::Bool = false)
     valid_pvalues(pValues)
     valid_pvalues([pi0])
     n = length(pValues)


### PR DESCRIPTION
Avoids parametric methods for scalar floating point input arguments. This also allows different floating point inputs to be of different concrete types.