### PR TITLE
Turn `PValues` type immutable and persistent

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -32,6 +32,8 @@ Base.convert{T<:AbstractFloat}(::Type{PValues}, x::AbstractVector{T}) = PValues(
 Base.size(pv::PValues) = (length(pv.values), )
 @compat Base.IndexStyle{T<:PValues}(::Type{T}) = IndexLinear()
 Base.getindex(pv::PValues, i::Integer) = pv.values[i]
+Base.setindex!(pv::PValues, x::AbstractFloat, i::Integer) =
+    throw(ErrorException("Modification of values is not permitted"))
 
 Base.values(pv::PValues) = pv.values
 Base.minimum(pv::PValues) = pv.min

--- a/src/types.jl
+++ b/src/types.jl
@@ -13,7 +13,7 @@
 
 ## PValues
 
-type PValues{T<:AbstractFloat} <: AbstractVector{T}
+immutable PValues{T<:AbstractFloat} <: AbstractVector{T}
     values::AbstractVector{T}
     min::T
     max::T
@@ -23,7 +23,7 @@ type PValues{T<:AbstractFloat} <: AbstractVector{T}
         if min < 0.0 || max > 1.0
             throw(DomainError())
         end
-        new{T}(values, min, max)
+        new{T}(copy(values), min, max)
     end
 end
 

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -14,7 +14,7 @@ using Base.Test
         pv = PValues(vals)
 
         # basic vector functionality
-        @test values(pv) ≡ vals
+        @test values(pv) == vals
         @test sum(pv) == sum(vals)
         @test length(pv) == n
         @test ones(pv) == ones(eltype(vals), n)
@@ -27,10 +27,10 @@ using Base.Test
         # min/max are taken from the type fields,
         # not recomputed from the values
         pvt = PValues(vals)
-        pvt.min = 0.0
-        pvt.max = 1.0
-        @test minimum(pvt) == 0.0
-        @test maximum(pvt) == 1.0
+        @test_throws ErrorException pvt.min = 0.0
+        @test_throws ErrorException pvt.max = 1.0
+        #@test minimum(pvt) == 0.0
+        #@test maximum(pvt) == 1.0
 
         # parametric type that keeps input float type
         for T in (Float16, Float32, Float64)
@@ -51,6 +51,29 @@ using Base.Test
         @test_throws MethodError PValues(0.5)
         @test_throws ArgumentError PValues([])
         @test_throws TypeError PValues([0, 1])
+
+    end
+
+
+    @testset "PValues immutability" begin
+
+        n = 10
+        vals = rand(n)
+        ref = deepcopy(vals)
+
+        pv = PValues(vals)
+
+        @test pv.values == ref
+        @test extrema(pv) == extrema(pv.values)
+
+        vals[1] = 0.0
+        vals[2] = 1.0
+
+        @test pv.values == ref
+        @test pv.values != vals
+        @test extrema(pv) == extrema(pv.values)
+
+        @test_throws ErrorException pv[1] = 0.0
 
     end
 

--- a/test/test-types.jl
+++ b/test/test-types.jl
@@ -29,8 +29,6 @@ using Base.Test
         pvt = PValues(vals)
         @test_throws ErrorException pvt.min = 0.0
         @test_throws ErrorException pvt.max = 1.0
-        #@test minimum(pvt) == 0.0
-        #@test maximum(pvt) == 1.0
 
         # parametric type that keeps input float type
         for T in (Float16, Float32, Float64)


### PR DESCRIPTION
This change modifies the definition and construction of the `PValues` type, in order to achieve a persistent representation of the data. Since the actual p-value vector in the type are mutable, even with an immutable `PValues` type, changes to the original object representing the p-values affect the validity and consistency of the `PValues` object:

```julia
p = collect(0.1:0.1:0.9)
pv = PValues(p)
p[1] = -10.0
minimum(p) # => 0.1, not updated
```

As a consequence,
a) the extrema stored in the object may not match the extrema of the actual values anymore
b) the object can become invalid without noticing, although the validity was checked at the initial construction.

In the new version, the p-value vector is copied during construction which address these issues. This comes at the cost of copying the vector once during construction, but it appears neglectable in the light of either having to deal with potentially invalid p-values.