### PR TITLE
Require successful tests with julia v0.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,10 +3,6 @@ environment:
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
 
-matrix:
-  allow_failures:
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-
 notifications:
   - provider: Email
     on_build_success: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ julia:
   - 0.5
   - 0.6
 
-matrix:
-  allow_failures:
-    - julia: 0.6
-
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Makes the tests with julia 0.6 mandatory since the RC is available (#35).