### PR TITLE
Switch to new `Weights` type in StatsBase

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # MultipleTesting.jl News and Changes
 
+## Version 0.2.3
+
+### Changes
+
+- Switch to new `Weights` type in 'StatsBase' (>= v0.15.0)
+
+
 ## Version 0.2.2
 
 ### Changes

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
-StatsBase
+StatsBase 0.15.0
 Distributions
 Compat 0.19.0

--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -2,7 +2,7 @@
 
 combine{T<:AbstractFloat, M<:PValueCombination}(pValues::AbstractVector{T}, method::M) = combine(PValues(pValues), method)
 
-combine{T<:AbstractFloat, M<:PValueCombination}(pValues::AbstractVector{T}, weights::WeightVec, method::M) = combine(PValues(pValues), weights, method)
+combine{T<:AbstractFloat, M<:PValueCombination}(pValues::AbstractVector{T}, weights::Weights, method::M) = combine(PValues(pValues), weights, method)
 
 combine{T<:AbstractFloat, R<:Real, M<:PValueCombination}(pValues::AbstractVector{T}, weights::AbstractVector{R}, method::M) = combine(PValues(pValues), weights, method)
 
@@ -68,7 +68,7 @@ function combine{T<:AbstractFloat}(pValues::PValues{T}, weights::Vector{T}, meth
     stouffer_combination(pValues, weights)
 end
 
-function combine{T<:AbstractFloat}(pValues::PValues{T}, weights::WeightVec, method::StoufferCombination)
+function combine{T<:AbstractFloat}(pValues::PValues{T}, weights::Weights, method::StoufferCombination)
     stouffer_combination(pValues, values(weights))
 end
 

--- a/test/test-combinations.jl
+++ b/test/test-combinations.jl
@@ -139,35 +139,32 @@ using Base.Test
 
         method = StoufferCombination
 
-        # `WeightVec` and `weights` are the same
-        @test WeightVec(w3) ≡ weights(w3)
-
         ref = ref1[method]
         @test isapprox( combine(p1, ones(p1), method()), ref, atol = 1e-8)
-        @test isapprox( combine(p1, weights(ones(p1)), method()), ref, atol = 1e-8)
-        @test isapprox( combine(PValues(p1), weights(ones(p1)), method()), ref, atol = 1e-8)
+        @test isapprox( combine(p1, Weights(ones(p1)), method()), ref, atol = 1e-8)
+        @test isapprox( combine(PValues(p1), Weights(ones(p1)), method()), ref, atol = 1e-8)
 
         ref = ref2[method]
         @test isapprox( combine(p2, ones(p2), method()), ref, atol = 1e-8)
-        @test isapprox( combine(p2, weights(ones(p2)), method()), ref, atol = 1e-8)
-        @test isapprox( combine(PValues(p2), weights(ones(p2)), method()), ref, atol = 1e-8)
+        @test isapprox( combine(p2, Weights(ones(p2)), method()), ref, atol = 1e-8)
+        @test isapprox( combine(PValues(p2), Weights(ones(p2)), method()), ref, atol = 1e-8)
 
         ref = ref3[method]
         w3norm = w3 ./ sum(w3)
         # unnormalised weights
         @test isapprox( combine(p3, w3, method()), ref, atol = 1e-8 )
-        @test isapprox( combine(p3, weights(w3), method()), ref, atol = 1e-8 )
+        @test isapprox( combine(p3, Weights(w3), method()), ref, atol = 1e-8 )
         # normalised weights
         @test isapprox( combine(p3, w3norm, method()), ref, atol = 1e-8 )
-        @test isapprox( combine(p3, weights(w3norm), method()), ref, atol = 1e-8 )
+        @test isapprox( combine(p3, Weights(w3norm), method()), ref, atol = 1e-8 )
 
         @test_throws DomainError combine(p1_invalid, ones(p1_invalid), method())
-        @test_throws DomainError combine(p1_invalid, weights(ones(p1_invalid)), method())
+        @test_throws DomainError combine(p1_invalid, Weights(ones(p1_invalid)), method())
         @test_throws DomainError combine(p2_invalid, ones(p2_invalid), method())
-        @test_throws DomainError combine(p2_invalid, weights(ones(p2_invalid)), method())
+        @test_throws DomainError combine(p2_invalid, Weights(ones(p2_invalid)), method())
 
         @test combine(p_single, ones(p_single), method()) == p_single[1]
-        @test combine(p_single, weights(ones(p_single)), method()) == p_single[1]
+        @test combine(p_single, Weights(ones(p_single)), method()) == p_single[1]
 
     end
 


### PR DESCRIPTION
The `WeightVec` type has been deprecated in newer version of StatsBase (>= 0.15.0), use the new `Weights` type instead.