### PR TITLE
Drop `Compat` dependency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,12 +5,13 @@
 ### Changes
 
 - Drop support for julia 0.5, require julia 0.6 as minimum version
-- Support new Distributions.jl interface
+- Drop `Compat` dependency
+- Support new `Distributions` interface
 
 
 ### Support
 
-- Requires julia 0.6 or newer
+- Requires julia 0.6
 
 
 ## Version 0.2.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.6
 StatsBase 0.15.0
 Distributions 0.14.1
-Compat 0.19.0


### PR DESCRIPTION
Compat is no longer needed since only julia 0.6 is currently supported.