### PR TITLE
Rename `estimate_pi0` to `estimate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ adjust(pvals, n, PValueAdjustmentMethod)
 * Oracle for known π₀
 
 ```julia
-estimate_pi0(pvals, Storey())
-estimate_pi0(pvals, StoreyBootstrap())
-estimate_pi0(pvals, LeastSlope())
-estimate_pi0(pvals, TwoStep())
-estimate_pi0(pvals, TwoStep(0.05))
-estimate_pi0(pvals, TwoStep(0.05, BenjaminiHochbergAdaptive(0.9))
-estimate_pi0(pvals, RightBoundary())
-estimate_pi0(pvals, CensoredBUM())
-estimate_pi0(pvals, BUM())
-estimate_pi0(pvals, FlatGrenander())
-estimate_pi0(pvals, Oracle(0.9))
+estimate(pvals, Storey())
+estimate(pvals, StoreyBootstrap())
+estimate(pvals, LeastSlope())
+estimate(pvals, TwoStep())
+estimate(pvals, TwoStep(0.05))
+estimate(pvals, TwoStep(0.05, BenjaminiHochbergAdaptive(0.9))
+estimate(pvals, RightBoundary())
+estimate(pvals, CensoredBUM())
+estimate(pvals, BUM())
+estimate(pvals, FlatGrenander())
+estimate(pvals, Oracle(0.9))
 ```
 
 

--- a/docs/notebooks/pi0-estimation.ipynb
+++ b/docs/notebooks/pi0-estimation.ipynb
@@ -341,7 +341,7 @@
     "for i in 1:m\n",
     "    pvals = rand(bum, m)\n",
     "    for (j, e) in enumerate(estimators)\n",
-    "        pi0hat[i,j] = estimate_pi0(pvals, e())\n",
+    "        pi0hat[i,j] = estimate(pvals, e())\n",
     "    end\n",
     "end"
    ]

--- a/src/MultipleTesting.jl
+++ b/src/MultipleTesting.jl
@@ -12,6 +12,7 @@ using StatsBase
 import StatsBase: fit
 
 using Distributions
+import Distributions: estimate
 
 export
     PValues,
@@ -29,7 +30,7 @@ export
     ForwardStop,
     BarberCandes,
     qValues,
-    estimate_pi0,
+    estimate,
     Pi0Estimator,
     Storey,
     StoreyBootstrap,

--- a/src/pi0-estimators.jl
+++ b/src/pi0-estimators.jl
@@ -1,6 +1,6 @@
 ### estimators for π0 (pi0) ###
 
-estimate_pi0{T<:AbstractFloat, M<:Pi0Estimator}(pValues::AbstractVector{T}, method::M) = estimate_pi0(PValues(pValues), method)
+estimate{T<:AbstractFloat, M<:Pi0Estimator}(pValues::AbstractVector{T}, method::M) = estimate(PValues(pValues), method)
 
 
 ## Storey estimator ##
@@ -33,7 +33,7 @@ end
 
 Storey() = Storey(0.1)
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::Storey)
+function estimate{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::Storey)
     storey_pi0(pValues, pi0estimator.λ)
 end
 
@@ -62,7 +62,7 @@ end
 
 StoreyBootstrap() = StoreyBootstrap(0.05:0.05:0.95, 0.1)
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::StoreyBootstrap)
+function estimate{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::StoreyBootstrap)
     bootstrap_pi0(pValues, pi0estimator.λseq, pi0estimator.q)
 end
 
@@ -87,7 +87,7 @@ LeastSlope()
 immutable LeastSlope <: Pi0Estimator
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::LeastSlope)
+function estimate{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::LeastSlope)
     lsl_pi0(pValues)
 end
 
@@ -140,7 +140,7 @@ end
 
 Oracle() = Oracle(1.0)
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::Oracle)
+function estimate{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::Oracle)
     pi0estimator.π0
 end
 
@@ -165,7 +165,7 @@ TwoStep() = TwoStep(0.05)
 
 TwoStep(α) = TwoStep(α, BenjaminiHochberg())
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::TwoStep)
+function estimate{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::TwoStep)
     twostep_pi0(pValues, pi0estimator.α, pi0estimator.method)
 end
 
@@ -193,7 +193,7 @@ end
 # λseq used in Liang, Nettleton 2012
 RightBoundary() = RightBoundary([0.02:0.02:0.1; 0.15:0.05:0.95])
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::RightBoundary)
+function estimate{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::RightBoundary)
     rightboundary_pi0(pValues, pi0estimator.λseq)
 end
 
@@ -250,11 +250,11 @@ function fit{T<:AbstractFloat}(pi0estimator::CensoredBUM, pValues::AbstractVecto
     return CensoredBUMFit(π0, param, is_converged)
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::CensoredBUM)
-    estimate_pi0(fit(pi0estimator, pValues))
+function estimate{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::CensoredBUM)
+    estimate(fit(pi0estimator, pValues))
 end
 
-function estimate_pi0(pi0fit::CensoredBUMFit)
+function estimate(pi0fit::CensoredBUMFit)
     pi0 = pi0fit.is_converged ? pi0fit.π0 : NaN
     return pi0
 end
@@ -367,11 +367,11 @@ function fit{T<:AbstractFloat}(pi0estimator::BUM, pValues::AbstractVector{T};
     return BUMFit(π0, param, is_converged)
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::BUM)
-    estimate_pi0(fit(pi0estimator, pValues))
+function estimate{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::BUM)
+    estimate(fit(pi0estimator, pValues))
 end
 
-function estimate_pi0(pi0fit::BUMFit)
+function estimate(pi0fit::BUMFit)
     pi0 = pi0fit.is_converged ? pi0fit.π0 : NaN
     return pi0
 end
@@ -391,7 +391,7 @@ Reference: Langaas et al., 2005: section 4.3
 immutable FlatGrenander <: Pi0Estimator
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::FlatGrenander)
+function estimate{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::FlatGrenander)
     flat_grenander_pi0(pValues)
 end
 

--- a/src/pval-adjustment.jl
+++ b/src/pval-adjustment.jl
@@ -61,7 +61,7 @@ BenjaminiHochbergAdaptive() = BenjaminiHochbergAdaptive(1.0)
 adjust(pvals::PValues, method::BenjaminiHochbergAdaptive) = adjust(pvals, length(pvals), method)
 
 function adjust(pvals::PValues, n::Integer, method::BenjaminiHochbergAdaptive)
-    π0 = estimate_pi0(pvals, method.pi0estimator)
+    π0 = estimate(pvals, method.pi0estimator)
     return benjamini_hochberg(pvals, n) * π0
 end
 

--- a/test/test-pi0-estimators.jl
+++ b/test/test-pi0-estimators.jl
@@ -22,18 +22,18 @@ using StatsBase
 
         @test issubtype(typeof(Storey()), Pi0Estimator)
         @test issubtype(typeof(Storey(0.5)), Pi0Estimator)
-        @test estimate_pi0(p, Storey(0.2)) ≈ 0.6
-        @test estimate_pi0(p, Storey(0.0)) ≈ 1.0
-        @test estimate_pi0(p, Storey(1.0)) ≈ 1.0
+        @test estimate(p, Storey(0.2)) ≈ 0.6
+        @test estimate(p, Storey(0.0)) ≈ 1.0
+        @test estimate(p, Storey(1.0)) ≈ 1.0
 
         p_unsort = unsort(p)
         @test !issorted(p_unsort)
-        @test estimate_pi0(p_unsort, Storey(0.2)) ≈ 0.6
+        @test estimate(p_unsort, Storey(0.2)) ≈ 0.6
         @test !issorted(p_unsort)
 
         @test_throws DomainError Storey(-0.1)
         @test_throws DomainError Storey(1.1)
-        #@test_throws DomainError estimate_pi0(p, Storey(1.0)) ## CHCK
+        #@test_throws DomainError estimate(p, Storey(1.0)) ## CHCK
 
     end
 
@@ -44,18 +44,18 @@ using StatsBase
 
         @test issubtype(typeof(StoreyBootstrap()), Pi0Estimator)
 
-        @test estimate_pi0(p, StoreyBootstrap()) ≈ 0.6
-        @test estimate_pi0(p0, StoreyBootstrap()) ≈ 1.0
-        @test estimate_pi0(p1, StoreyBootstrap()) ≈ 0.15
+        @test estimate(p, StoreyBootstrap()) ≈ 0.6
+        @test estimate(p0, StoreyBootstrap()) ≈ 1.0
+        @test estimate(p1, StoreyBootstrap()) ≈ 0.15
 
-        @test estimate_pi0(p, StoreyBootstrap(lambdas, q)) ≈ 0.6
-        @test estimate_pi0(p0, StoreyBootstrap(lambdas, q)) ≈ 1.0
-        @test estimate_pi0(p1, StoreyBootstrap(lambdas, q)) ≈ 0.15
+        @test estimate(p, StoreyBootstrap(lambdas, q)) ≈ 0.6
+        @test estimate(p0, StoreyBootstrap(lambdas, q)) ≈ 1.0
+        @test estimate(p1, StoreyBootstrap(lambdas, q)) ≈ 0.15
 
         ## unsorted lambdas
         lambdas_unsort = unsort(lambdas)
         @test !issorted(lambdas_unsort)
-        @test estimate_pi0(p, StoreyBootstrap(lambdas_unsort, q)) ≈ 0.6
+        @test estimate(p, StoreyBootstrap(lambdas_unsort, q)) ≈ 0.6
         @test !issorted(lambdas_unsort)
 
         @test_throws DomainError StoreyBootstrap(lambdas, -0.1)
@@ -72,21 +72,21 @@ using StatsBase
         @test issubtype(typeof(LeastSlope()), Pi0Estimator)
 
         ## checked against structSSI::pi0.lsl
-        @test isapprox( estimate_pi0(p, LeastSlope()), 0.62, atol = 1e-2 )
-        @test isapprox( estimate_pi0(p0, LeastSlope()), 1.0, atol = 1e-2 )
-        @test isapprox( estimate_pi0(p1, LeastSlope()), 0.16, atol = 1e-2 )
+        @test isapprox( estimate(p, LeastSlope()), 0.62, atol = 1e-2 )
+        @test isapprox( estimate(p0, LeastSlope()), 1.0, atol = 1e-2 )
+        @test isapprox( estimate(p1, LeastSlope()), 0.16, atol = 1e-2 )
 
         ## check against internal reference implementation
-        @test estimate_pi0(p, LeastSlope()) ≈ MultipleTesting.lsl_pi0_vec(p)
-        @test estimate_pi0(p0, LeastSlope()) ≈ MultipleTesting.lsl_pi0_vec(p0)
-        @test estimate_pi0(p1, LeastSlope()) ≈ MultipleTesting.lsl_pi0_vec(p1)
+        @test estimate(p, LeastSlope()) ≈ MultipleTesting.lsl_pi0_vec(p)
+        @test estimate(p0, LeastSlope()) ≈ MultipleTesting.lsl_pi0_vec(p0)
+        @test estimate(p1, LeastSlope()) ≈ MultipleTesting.lsl_pi0_vec(p1)
 
         @test_throws MethodError LeastSlope(0.1)
 
         ## unsorted p-values
         p_unsort = unsort(p)
         @test !issorted(p_unsort)
-        @test isapprox( estimate_pi0(p_unsort, LeastSlope()), 0.62, atol = 1e-2 )
+        @test isapprox( estimate(p_unsort, LeastSlope()), 0.62, atol = 1e-2 )
         @test !issorted(p_unsort)
 
         p_unsort = unsort(p)
@@ -99,9 +99,9 @@ using StatsBase
 
     @testset "Oracle π0" begin
 
-        @test estimate_pi0(p, Oracle(0.5)) == 0.5
-        @test estimate_pi0(p0, Oracle(0.6)) == 0.6
-        @test estimate_pi0(p1, Oracle()) == 1.0
+        @test estimate(p, Oracle(0.5)) == 0.5
+        @test estimate(p0, Oracle(0.6)) == 0.6
+        @test estimate(p1, Oracle()) == 1.0
 
     end
 
@@ -113,21 +113,21 @@ using StatsBase
         @test issubtype(typeof(TwoStep(alpha)), Pi0Estimator)
 
         ## checked against mutoss::TSBKY_pi0_est
-        @test estimate_pi0(p, TwoStep()) ≈ 0.665
-        @test estimate_pi0(p, TwoStep(alpha)) ≈ 0.665
-        @test estimate_pi0(p0, TwoStep(alpha)) ≈ 1.0
-        @test estimate_pi0(p1, TwoStep(alpha)) ≈ 0.29
-        @test estimate_pi0(p, TwoStep(alpha, BenjaminiHochberg())) ≈ 0.665
+        @test estimate(p, TwoStep()) ≈ 0.665
+        @test estimate(p, TwoStep(alpha)) ≈ 0.665
+        @test estimate(p0, TwoStep(alpha)) ≈ 1.0
+        @test estimate(p1, TwoStep(alpha)) ≈ 0.29
+        @test estimate(p, TwoStep(alpha, BenjaminiHochberg())) ≈ 0.665
 
-        @test estimate_pi0(p, TwoStep(0.1)) ≈ 0.63
-        @test estimate_pi0(p, TwoStep(0.0)) ≈ 1.0
-        @test estimate_pi0(p, TwoStep(1.0)) ≈ 0.415
-        @test estimate_pi0(p, TwoStep(0.1, BenjaminiHochberg())) ≈ 0.63
+        @test estimate(p, TwoStep(0.1)) ≈ 0.63
+        @test estimate(p, TwoStep(0.0)) ≈ 1.0
+        @test estimate(p, TwoStep(1.0)) ≈ 0.415
+        @test estimate(p, TwoStep(0.1, BenjaminiHochberg())) ≈ 0.63
 
         ## unsorted p-values
         p_unsort = unsort(p)
         @test !issorted(p_unsort)
-        @test estimate_pi0(p_unsort, TwoStep(alpha)) ≈ 0.665
+        @test estimate(p_unsort, TwoStep(alpha)) ≈ 0.665
         @test !issorted(p_unsort)
 
     end
@@ -153,18 +153,18 @@ using StatsBase
         @test issubtype(typeof(RightBoundary(lambdas)), Pi0Estimator)
 
         # only eps because pi0 package uses right closed histograms
-        @test isapprox( estimate_pi0(p, RightBoundary(lambdas)), 0.5714286, atol = 0.02 )
-        @test estimate_pi0(p0, RightBoundary(lambdas)) ≈ 1.0
-        @test isapprox( estimate_pi0(p1, RightBoundary(lambdas)), 0.1428571, atol = 1e-7 )
+        @test isapprox( estimate(p, RightBoundary(lambdas)), 0.5714286, atol = 0.02 )
+        @test estimate(p0, RightBoundary(lambdas)) ≈ 1.0
+        @test isapprox( estimate(p1, RightBoundary(lambdas)), 0.1428571, atol = 1e-7 )
 
-        @test estimate_pi0(p, RightBoundary(lambdas)) ≈ estimate_pi0(p, RightBoundary(unsort(lambdas)))
+        @test estimate(p, RightBoundary(lambdas)) ≈ estimate(p, RightBoundary(unsort(lambdas)))
 
         # not checked against R implementation but should hold (check for default lambda grid)
-        @test estimate_pi0(p0, RightBoundary()) ≈ 1.0
+        @test estimate(p0, RightBoundary()) ≈ 1.0
 
         p_unsort = unsort(p1)
         @test !issorted(p_unsort)
-        @test isapprox( estimate_pi0(p_unsort, RightBoundary(lambdas)), 0.1428571, atol = 1e-7 )
+        @test isapprox( estimate(p_unsort, RightBoundary(lambdas)), 0.1428571, atol = 1e-7 )
         @test !issorted(p_unsort)
 
     end
@@ -175,18 +175,18 @@ using StatsBase
         @test issubtype(typeof(CensoredBUM()), Pi0Estimator)
         @test issubtype(typeof(CensoredBUM(0.2, 0.1)), Pi0Estimator)
 
-        @test isapprox( estimate_pi0(p, CensoredBUM()), 0.55797, atol = 1e-5 )
-        @test isapprox( estimate_pi0(p0, CensoredBUM()), 1.0, atol = 1e-5 )
-        @test isapprox( estimate_pi0(p1, CensoredBUM()), 0.11608, atol = 2e-5 )
+        @test isapprox( estimate(p, CensoredBUM()), 0.55797, atol = 1e-5 )
+        @test isapprox( estimate(p0, CensoredBUM()), 1.0, atol = 1e-5 )
+        @test isapprox( estimate(p1, CensoredBUM()), 0.11608, atol = 2e-5 )
 
         # test against internal reference implementation
         # p0 case is not handled well by naive implementation
-        @test estimate_pi0(p, CensoredBUM()) ≈ MultipleTesting.cbum_pi0_naive(p)[1]
-        @test estimate_pi0(p1, CensoredBUM()) ≈ MultipleTesting.cbum_pi0_naive(p1)[1]
+        @test estimate(p, CensoredBUM()) ≈ MultipleTesting.cbum_pi0_naive(p)[1]
+        @test estimate(p1, CensoredBUM()) ≈ MultipleTesting.cbum_pi0_naive(p1)[1]
 
         ## test case that does not converge
         stderr_dump = redirect_stderr()
-        @test isnan(estimate_pi0(p, CensoredBUM(0.5, 0.05, 1e-6, 2)))
+        @test isnan(estimate(p, CensoredBUM(0.5, 0.05, 1e-6, 2)))
 
         @test_throws DomainError CensoredBUM(-0.5, 0.05)
         @test_throws DomainError CensoredBUM(1.5, 0.05)
@@ -202,7 +202,7 @@ using StatsBase
         @test isapprox( f.π0, 0.55797, atol = 1e-5 )
 
         # denominator becomes 0 if all p-values are 1
-        @test isnan( estimate_pi0(ones(20), CensoredBUM()) )
+        @test isnan( estimate(ones(20), CensoredBUM()) )
 
         pi0_est, pars, is_converged = MultipleTesting.cbum_pi0(ones(20))
         @test isnan( pi0_est )
@@ -217,13 +217,13 @@ using StatsBase
 
     @testset "BUM π0" begin
 
-        @test isapprox( estimate_pi0(p, BUM(0.5)), 0.55528, atol = 1e-5 )
-        @test isapprox( estimate_pi0(p, BUM()), 0.55528, atol = 1e-5 )
-        @test isapprox( estimate_pi0(p0, BUM()), 1.0, atol = 1e-5 )
-        @test isapprox( estimate_pi0(p1, BUM()), 0.10874, atol = 1e-5 )
+        @test isapprox( estimate(p, BUM(0.5)), 0.55528, atol = 1e-5 )
+        @test isapprox( estimate(p, BUM()), 0.55528, atol = 1e-5 )
+        @test isapprox( estimate(p0, BUM()), 1.0, atol = 1e-5 )
+        @test isapprox( estimate(p1, BUM()), 0.10874, atol = 1e-5 )
 
         ## test case that does not converge
-        @test isnan(estimate_pi0(p, BUM(0.5, 1e-6, 2)))
+        @test isnan(estimate(p, BUM(0.5, 1e-6, 2)))
 
         @test issubtype(typeof(BUM()), Pi0Estimator)
 
@@ -238,13 +238,13 @@ using StatsBase
         @test issubtype(typeof(FlatGrenander()), Pi0Estimator)
 
         pu = collect(0.1:0.05:0.9)
-        @test estimate_pi0(pu, FlatGrenander()) ≈ 1.0
-        @test estimate_pi0(pu.^0.5, FlatGrenander()) ≈ 1.0
+        @test estimate(pu, FlatGrenander()) ≈ 1.0
+        @test estimate(pu.^0.5, FlatGrenander()) ≈ 1.0
 
         # no reference values from literature/software available
-        @test estimate_pi0(p0, FlatGrenander()) ≈ 1.0
-        @test isapprox( estimate_pi0(p1, FlatGrenander()), 0.10458, atol = 1e-4 )
-        @test isapprox( estimate_pi0(p, FlatGrenander()), pi0, atol = 0.1)
+        @test estimate(p0, FlatGrenander()) ≈ 1.0
+        @test isapprox( estimate(p1, FlatGrenander()), 0.10458, atol = 1e-4 )
+        @test isapprox( estimate(p, FlatGrenander()), pi0, atol = 0.1)
 
         ## longest constant interval: low level
         lci = MultipleTesting.longest_constant_interval

--- a/test/test-pval-pi0-adjustment.jl
+++ b/test/test-pval-pi0-adjustment.jl
@@ -43,9 +43,9 @@ using Base.Test
         @test isapprox( adjust(pval1, t(0.0)), zeros(ref0), atol = 1e-8 )
 
         # adaptive with pi0 estimator == oracle with estimated pi0
-        @test adjust(pval1, t(Storey())) == adjust(pval1, t(estimate_pi0(pval1, Storey())))
-        @test adjust(pval1, t(Storey(0.3))) == adjust(pval1, t(estimate_pi0(pval1, Storey(0.3))))
-        @test adjust(pval1, t(LeastSlope())) == adjust(pval1, t(estimate_pi0(pval1, LeastSlope())))
+        @test adjust(pval1, t(Storey())) == adjust(pval1, t(estimate(pval1, Storey())))
+        @test adjust(pval1, t(Storey(0.3))) == adjust(pval1, t(estimate(pval1, Storey(0.3))))
+        @test adjust(pval1, t(LeastSlope())) == adjust(pval1, t(estimate(pval1, LeastSlope())))
 
     end
 


### PR DESCRIPTION
Implements the changes outlined in #59. `estimate` is extended from `Distributions.`