### PR TITLE
Remove leftovers from julia v0.5

### DIFF
--- a/src/pi0-estimators.jl
+++ b/src/pi0-estimators.jl
@@ -305,7 +305,7 @@ function cbum_pi0_naive{T<:AbstractFloat}(pValues::AbstractVector{T},
     n = length(pValues)
     z = fill(1-γ0, n)
     idx_left = pValues .< λ
-    idx_right = @__dot__ !idx_left
+    idx_right = .!idx_left
     pi0_old = γ0 = α = γ = Inf
     # compute constant values only once
     lpr = log.(pValues[idx_right])

--- a/src/types.jl
+++ b/src/types.jl
@@ -35,7 +35,6 @@ Base.getindex(pv::PValues, i::Integer) = pv.values[i]
 Base.setindex!(pv::PValues, x::AbstractFloat, i::Integer) =
     throw(ErrorException("Modification of values is not permitted"))
 
-Base.values(pv::PValues) = pv.values
 Base.minimum(pv::PValues) = pv.min
 Base.maximum(pv::PValues) = pv.max
 Base.extrema(pv::PValues) = (minimum(pv), maximum(pv))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,8 +6,6 @@ function reorder{T<:Real}(values::AbstractVector{T})
     return newOrder, oldOrder
 end
 
-reorder(pv::PValues) = reorder(values(pv))
-
 
 function sort_if_needed(x; kws...)
     if issorted(x; kws...)

--- a/test/test-pval-pi0-adjustment.jl
+++ b/test/test-pval-pi0-adjustment.jl
@@ -104,10 +104,7 @@ using Base.Test
         @test m(pval, pi0) == pval .* pi0
 
         ## compare with reference values
-        # `isapprox` cannot compare NaNs in julia 0.5
-        # TODO use `isapprox(nans = true)` in julia 0.6
-        idx = @__dot__ !isnan.(ref)
-        @test isapprox( m(pval1, pi0, true)[idx], ref[idx], atol = 1e-8 )
+        @test isapprox( m(pval1, pi0, true), ref, atol = 1e-8, nans = true )
 
     end
 


### PR DESCRIPTION
Removes obsolete compatibility syntax, workarounds and methods.