### PR TITLE
Switch to new julia syntax

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
 StatsBase 0.15.0
 Distributions 0.14.1
+SpecialFunctions 0.3.8

--- a/src/MultipleTesting.jl
+++ b/src/MultipleTesting.jl
@@ -14,6 +14,8 @@ import StatsBase: fit
 using Distributions
 import Distributions: estimate
 
+import SpecialFunctions: digamma
+
 export
     PValues,
     adjust,

--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -1,22 +1,28 @@
 ### Combination methods for p-values ###
 
-combine{T<:AbstractFloat, M<:PValueCombination}(pValues::AbstractVector{T}, method::M) = combine(PValues(pValues), method)
+function combine(pValues::AbstractVector{T}, method::M) where {T<:AbstractFloat, M<:PValueCombination}
+    combine(PValues(pValues), method)
+end
 
-combine{T<:AbstractFloat, M<:PValueCombination}(pValues::AbstractVector{T}, weights::Weights, method::M) = combine(PValues(pValues), weights, method)
+function combine(pValues::AbstractVector{T}, weights::Weights, method::M) where {T<:AbstractFloat, M<:PValueCombination}
+    combine(PValues(pValues), weights, method)
+end
 
-combine{T<:AbstractFloat, R<:Real, M<:PValueCombination}(pValues::AbstractVector{T}, weights::AbstractVector{R}, method::M) = combine(PValues(pValues), weights, method)
+function combine(pValues::AbstractVector{T}, weights::AbstractVector{R}, method::M) where {T<:AbstractFloat, R<:Real, M<:PValueCombination}
+    combine(PValues(pValues), weights, method)
+end
 
 
 ## Fisher combination ##
 
-immutable FisherCombination <: PValueCombination
+struct FisherCombination <: PValueCombination
 end
 
-function combine{T<:AbstractFloat}(pValues::PValues{T}, method::FisherCombination)
+function combine(pValues::PValues{T}, method::FisherCombination) where T<:AbstractFloat
     fisher_combination(pValues)
 end
 
-function fisher_combination{T<:AbstractFloat}(pValues::PValues{T})
+function fisher_combination(pValues::PValues{T}) where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -32,14 +38,14 @@ end
 
 ## Logit combination ##
 
-immutable LogitCombination <: PValueCombination
+struct LogitCombination <: PValueCombination
 end
 
-function combine{T<:AbstractFloat}(pValues::PValues{T}, method::LogitCombination)
+function combine(pValues::PValues{T}, method::LogitCombination) where T<:AbstractFloat
     logit_combination(pValues)
 end
 
-function logit_combination{T<:AbstractFloat}(pValues::PValues{T})
+function logit_combination(pValues::PValues{T}) where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -57,22 +63,22 @@ end
 
 ## Stouffer combination ##
 
-immutable StoufferCombination <: PValueCombination
+struct StoufferCombination <: PValueCombination
 end
 
-function combine{T<:AbstractFloat}(pValues::PValues{T}, method::StoufferCombination)
+function combine(pValues::PValues{T}, method::StoufferCombination) where T<:AbstractFloat
     stouffer_combination(pValues)
 end
 
-function combine{T<:AbstractFloat}(pValues::PValues{T}, weights::Vector{T}, method::StoufferCombination)
+function combine(pValues::PValues{T}, weights::Vector{T}, method::StoufferCombination) where T<:AbstractFloat
     stouffer_combination(pValues, weights)
 end
 
-function combine{T<:AbstractFloat}(pValues::PValues{T}, weights::Weights, method::StoufferCombination)
+function combine(pValues::PValues{T}, weights::Weights, method::StoufferCombination) where T<:AbstractFloat
     stouffer_combination(pValues, values(weights))
 end
 
-function stouffer_combination{T<:AbstractFloat}(pValues::PValues{T})
+function stouffer_combination(pValues::PValues{T}) where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -87,7 +93,7 @@ function stouffer_combination{T<:AbstractFloat}(pValues::PValues{T})
     return p
 end
 
-function stouffer_combination{T<:AbstractFloat}(pValues::PValues{T}, weights::Vector{T})
+function stouffer_combination(pValues::PValues{T}, weights::Vector{T}) where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -105,14 +111,14 @@ end
 
 ## Tippett combination ##
 
-immutable TippettCombination <: PValueCombination
+struct TippettCombination <: PValueCombination
 end
 
-function combine{T<:AbstractFloat}(pValues::PValues{T}, method::TippettCombination)
+function combine(pValues::PValues{T}, method::TippettCombination) where T<:AbstractFloat
     tippett_combination(pValues)
 end
 
-function tippett_combination{T<:AbstractFloat}(pValues::PValues{T})
+function tippett_combination(pValues::PValues{T}) where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -124,14 +130,14 @@ end
 
 ## Simes combination ##
 
-immutable SimesCombination <: PValueCombination
+struct SimesCombination <: PValueCombination
 end
 
-function combine{T<:AbstractFloat}(pValues::PValues{T}, method::SimesCombination)
+function combine(pValues::PValues{T}, method::SimesCombination) where T<:AbstractFloat
     simes_combination(pValues)
 end
 
-function simes_combination{T<:AbstractFloat}(pValues::PValues{T})
+function simes_combination(pValues::PValues{T}) where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -144,7 +150,7 @@ end
 
 ## Wilkinson combination ##
 
-immutable WilkinsonCombination <: PValueCombination
+struct WilkinsonCombination <: PValueCombination
     rank::Integer
 
     function WilkinsonCombination(rank)
@@ -155,11 +161,11 @@ immutable WilkinsonCombination <: PValueCombination
     end
 end
 
-function combine{T<:AbstractFloat}(pValues::PValues{T}, method::WilkinsonCombination)
+function combine(pValues::PValues{T}, method::WilkinsonCombination) where T<:AbstractFloat
     wilkinson_combination(pValues, method.rank)
 end
 
-function wilkinson_combination{T<:AbstractFloat}(pValues::PValues{T}, rank::Integer)
+function wilkinson_combination(pValues::PValues{T}, rank::Integer) where T<:AbstractFloat
     n = length(pValues)
     if rank < 1 || rank > n
         throw(ArgumentError("Rank must be in 1,..,$(n)"))
@@ -175,15 +181,15 @@ end
 
 ## Generalised minimum combination ##
 
-immutable MinimumCombination <: PValueCombination
+struct MinimumCombination <: PValueCombination
     method::PValueAdjustment
 end
 
-function combine{T<:AbstractFloat}(pValues::PValues{T}, method::MinimumCombination)
+function combine(pValues::PValues{T}, method::MinimumCombination) where T<:AbstractFloat
     minimum_combination(pValues, method.method)
 end
 
-function minimum_combination{T<:AbstractFloat}(pValues::PValues{T}, pAdjustMethod::PValueAdjustment)
+function minimum_combination(pValues::PValues{T}, pAdjustMethod::PValueAdjustment) where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]

--- a/src/higher-criticism.jl
+++ b/src/higher-criticism.jl
@@ -1,6 +1,7 @@
 ## Higher criticism
 
-struct HigherCriticismScores end
+struct HigherCriticismScores
+end
 
 function estimate(pValues::PValues{T}, method::HigherCriticismScores) where T<:AbstractFloat
     n = length(pValues)
@@ -14,7 +15,8 @@ function estimate(pValues::PValues{T}, method::HigherCriticismScores) where T<:A
 end
 
 
-struct HigherCriticismThreshold end
+struct HigherCriticismThreshold
+end
 
 function estimate(pValues::PValues{T}, method::HigherCriticismThreshold) where T<:AbstractFloat
     idx_hcv = indmax(estimate(pValues, HigherCriticismScores()))

--- a/src/pi0-estimators.jl
+++ b/src/pi0-estimators.jl
@@ -1,6 +1,8 @@
 ### estimators for π0 (pi0) ###
 
-estimate_pi0{T<:AbstractFloat, M<:Pi0Estimator}(pValues::AbstractVector{T}, method::M) = estimate_pi0(PValues(pValues), method)
+function estimate_pi0(pValues::AbstractVector{T}, method::M) where {T<:AbstractFloat, M<:Pi0Estimator}
+    estimate_pi0(PValues(pValues), method)
+end
 
 
 ## Storey estimator ##
@@ -25,7 +27,7 @@ Storey, JD (2002). "A Direct Approach to False Discovery Rates." Journal of the
 Royal Statistical Society, doi:10.1111/1467-9868.00346
 
 """
-immutable Storey <: Pi0Estimator
+struct Storey <: Pi0Estimator
     λ::AbstractFloat
 
     Storey(λ) = isin(λ, 0., 1.) ? new(λ) : throw(DomainError())
@@ -33,11 +35,11 @@ end
 
 Storey() = Storey(0.1)
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::Storey)
+function estimate_pi0(pValues::PValues{T}, pi0estimator::Storey) where T<:AbstractFloat
     storey_pi0(pValues, pi0estimator.λ)
 end
 
-function storey_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, lambda::AbstractFloat)
+function storey_pi0(pValues::AbstractVector{T}, lambda::AbstractFloat) where T<:AbstractFloat
     pi0 = (sum(pValues .>= lambda) / length(pValues)) / (1.-lambda)
     pi0 = min.(pi0, 1.)
     return pi0
@@ -52,7 +54,7 @@ StoreyBootstrap(λseq, q)
 
 Reference: David Robinson, 2012
 """
-immutable StoreyBootstrap <: Pi0Estimator
+struct StoreyBootstrap <: Pi0Estimator
     λseq::AbstractVector{AbstractFloat}
     q   ::AbstractFloat
 
@@ -62,11 +64,11 @@ end
 
 StoreyBootstrap() = StoreyBootstrap(0.05:0.05:0.95, 0.1)
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::StoreyBootstrap)
+function estimate_pi0(pValues::PValues{T}, pi0estimator::StoreyBootstrap) where T<:AbstractFloat
     bootstrap_pi0(pValues, pi0estimator.λseq, pi0estimator.q)
 end
 
-function bootstrap_pi0{T<:AbstractFloat,S<:AbstractFloat}(pValues::AbstractVector{T}, lambda::AbstractVector{S} = 0.05:0.05:0.95, q::S = 0.1)
+function bootstrap_pi0(pValues::AbstractVector{T}, lambda::AbstractVector{S} = 0.05:0.05:0.95, q::S = 0.1) where {T<:AbstractFloat,S<:AbstractFloat}
     n = length(pValues)
     w = [sum(pValues .>= l) for l in lambda]  # TODO: check if >= or >
     pi0 = w ./ n ./ (1. - lambda)
@@ -84,14 +86,14 @@ Least SLope (LSL) π0 estimator
 
 LeastSlope()
 """
-immutable LeastSlope <: Pi0Estimator
+struct LeastSlope <: Pi0Estimator
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::LeastSlope)
+function estimate_pi0(pValues::PValues{T}, pi0estimator::LeastSlope) where T<:AbstractFloat
     lsl_pi0(pValues)
 end
 
-function lsl_pi0{T<:AbstractFloat}(pValues::AbstractVector{T})
+function lsl_pi0(pValues::AbstractVector{T}) where T<:AbstractFloat
     n = length(pValues)
     pValues = sort_if_needed(pValues)
     s0 = lsl_slope(1, n, pValues)
@@ -108,14 +110,14 @@ function lsl_pi0{T<:AbstractFloat}(pValues::AbstractVector{T})
     return pi0
 end
 
-function lsl_slope{T<:AbstractFloat}(i::Integer, n::Integer, pval::AbstractVector{T})
+function lsl_slope(i::Integer, n::Integer, pval::AbstractVector{T}) where T<:AbstractFloat
     s = (1 - pval[i]) / (n - i + 1)
     return s
 end
 
 # alternative, vectorized version
 # used for comparison and compactness
-function lsl_pi0_vec{T<:AbstractFloat}(pValues::AbstractVector{T})
+function lsl_pi0_vec(pValues::AbstractVector{T}) where T<:AbstractFloat
     n = length(pValues)
     pValues = sort_if_needed(pValues)
     s = (1 - pValues) ./ (n:-1:1)
@@ -132,7 +134,7 @@ Oracle π0
 
 Oracle(π0)
 """
-immutable Oracle <: Pi0Estimator
+struct Oracle <: Pi0Estimator
     π0::AbstractFloat
 
     Oracle(π0) = isin(π0, 0., 1.) ? new(π0) : throw(DomainError())
@@ -140,7 +142,7 @@ end
 
 Oracle() = Oracle(1.0)
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::Oracle)
+function estimate_pi0(pValues::PValues{T}, pi0estimator::Oracle) where T<:AbstractFloat
     pi0estimator.π0
 end
 
@@ -154,7 +156,7 @@ TwoStep(α)
 
 Reference: Benjamini, Krieger and Yekutieli, 2006
 """
-immutable TwoStep <: Pi0Estimator
+struct TwoStep <: Pi0Estimator
     α::AbstractFloat
     method::PValueAdjustment
 
@@ -165,11 +167,11 @@ TwoStep() = TwoStep(0.05)
 
 TwoStep(α) = TwoStep(α, BenjaminiHochberg())
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::TwoStep)
+function estimate_pi0(pValues::PValues{T}, pi0estimator::TwoStep) where T<:AbstractFloat
     twostep_pi0(pValues, pi0estimator.α, pi0estimator.method)
 end
 
-function twostep_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, alpha::AbstractFloat, method::PValueAdjustment)
+function twostep_pi0(pValues::AbstractVector{T}, alpha::AbstractFloat, method::PValueAdjustment) where T<:AbstractFloat
     padj = adjust(pValues, method)
     pi0 = sum(padj .>= (alpha/(1+alpha))) / length(padj)
     return pi0
@@ -183,7 +185,7 @@ Right boundary π0 estimator
 
 RightBoundary(λseq)
 """
-immutable RightBoundary <: Pi0Estimator
+struct RightBoundary <: Pi0Estimator
     λseq::AbstractVector{Float64}
 
     RightBoundary(λseq) =
@@ -193,11 +195,11 @@ end
 # λseq used in Liang, Nettleton 2012
 RightBoundary() = RightBoundary([0.02:0.02:0.1; 0.15:0.05:0.95])
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::RightBoundary)
+function estimate_pi0(pValues::PValues{T}, pi0estimator::RightBoundary) where T<:AbstractFloat
     rightboundary_pi0(pValues, pi0estimator.λseq)
 end
 
-function rightboundary_pi0{T<:AbstractFloat}(pValues::AbstractVector{T}, λseq::AbstractVector{T})
+function rightboundary_pi0(pValues::AbstractVector{T}, λseq::AbstractVector{T}) where T<:AbstractFloat
     n = length(pValues)
     λseq = sort_if_needed(λseq)
     # make sure we catch p-values equal to 1 despite left closure
@@ -218,7 +220,7 @@ Censored BUM π0 estimator
 
 CensoredBUM(γ0, λ, xtol, maxiter)
 """
-immutable CensoredBUM <: Pi0Estimator
+struct CensoredBUM <: Pi0Estimator
     γ0::Float64
     λ::Float64
     xtol::Float64
@@ -236,21 +238,20 @@ end
 CensoredBUM() = CensoredBUM(0.5, 0.05, 1e-6, 10000)
 CensoredBUM(γ0, λ) = CensoredBUM(γ0, λ, 1e-6, 10000)
 
-immutable CensoredBUMFit <: Pi0Fit
+struct CensoredBUMFit <: Pi0Fit
     π0::Float64
     param::AbstractVector{Float64}
     is_converged::Bool
 end
 
-function fit{T<:AbstractFloat}(pi0estimator::CensoredBUM, pValues::AbstractVector{T};
-                               kw...)
+function fit(pi0estimator::CensoredBUM, pValues::AbstractVector{T}; kw...) where T<:AbstractFloat
     π0, param, is_converged = cbum_pi0(pValues, pi0estimator.γ0, pi0estimator.λ,
                                        pi0estimator.xtol, pi0estimator.maxiter;
                                        kw...)
     return CensoredBUMFit(π0, param, is_converged)
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::CensoredBUM)
+function estimate_pi0(pValues::PValues{T}, pi0estimator::CensoredBUM) where T<:AbstractFloat
     estimate_pi0(fit(pi0estimator, pValues))
 end
 
@@ -259,9 +260,9 @@ function estimate_pi0(pi0fit::CensoredBUMFit)
     return pi0
 end
 
-function cbum_pi0{T<:AbstractFloat}(pValues::AbstractVector{T},
-                                    γ0::AbstractFloat = 0.5, λ::AbstractFloat = 0.05,
-                                    xtol::AbstractFloat = 1e-6, maxiter::Integer = 10000)
+function cbum_pi0(pValues::AbstractVector{T},
+                  γ0::AbstractFloat = 0.5, λ::AbstractFloat = 0.05,
+                  xtol::AbstractFloat = 1e-6, maxiter::Integer = 10000) where T<:AbstractFloat
     n = length(pValues)
     idx_right = pValues .>= λ
     n2 = sum(idx_right)
@@ -299,9 +300,9 @@ function cbum_pi0{T<:AbstractFloat}(pValues::AbstractVector{T},
     return NaN, [γ, α], false
 end
 
-function cbum_pi0_naive{T<:AbstractFloat}(pValues::AbstractVector{T},
-                                          γ0::AbstractFloat = 0.5, λ::AbstractFloat = 0.05,
-                                          xtol::AbstractFloat = 1e-6, maxiter::Integer = 10000)
+function cbum_pi0_naive(pValues::AbstractVector{T},
+                        γ0::AbstractFloat = 0.5, λ::AbstractFloat = 0.05,
+                        xtol::AbstractFloat = 1e-6, maxiter::Integer = 10000) where T<:AbstractFloat
     n = length(pValues)
     z = fill(1-γ0, n)
     idx_left = pValues .< λ
@@ -335,7 +336,7 @@ BUM π0 estimator
 
 BUM(γ0, xtol, maxiter)
 """
-immutable BUM <: Pi0Estimator
+struct BUM <: Pi0Estimator
     γ0::Float64
     xtol::Float64
     maxiter::Int64
@@ -353,21 +354,20 @@ BUM() = BUM(0.5, 1e-6, 10000)
 
 BUM(y0::Float64) = BUM(y0, 1e-6, 10000)
 
-immutable BUMFit <: Pi0Fit
+struct BUMFit <: Pi0Fit
     π0::Float64
     param::AbstractVector{Float64}
     is_converged::Bool
 end
 
-function fit{T<:AbstractFloat}(pi0estimator::BUM, pValues::AbstractVector{T};
-                               kw...)
+function fit(pi0estimator::BUM, pValues::AbstractVector{T}; kw...) where T<:AbstractFloat
     π0, param, is_converged = cbum_pi0(pValues, pi0estimator.γ0, eps(),
                                        pi0estimator.xtol, pi0estimator.maxiter;
                                        kw...)
     return BUMFit(π0, param, is_converged)
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::BUM)
+function estimate_pi0(pValues::PValues{T}, pi0estimator::BUM) where T<:AbstractFloat
     estimate_pi0(fit(pi0estimator, pValues))
 end
 
@@ -388,20 +388,20 @@ Estimates π0 by the longest constant interval in the Grenander estimator
 
 Reference: Langaas et al., 2005: section 4.3
 """
-immutable FlatGrenander <: Pi0Estimator
+struct FlatGrenander <: Pi0Estimator
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::FlatGrenander)
+function estimate_pi0(pValues::PValues{T}, pi0estimator::FlatGrenander) where T<:AbstractFloat
     flat_grenander_pi0(pValues)
 end
 
-function flat_grenander_pi0{T<:AbstractFloat}(pv::AbstractVector{T})
+function flat_grenander_pi0(pv::AbstractVector{T}) where T<:AbstractFloat
     p, f, F = grenander(pv)
     pi0 = longest_constant_interval(p, f)
     return pi0
 end
 
-function longest_constant_interval{T<:AbstractFloat}(p::AbstractVector{T}, f::AbstractVector{T})
+function longest_constant_interval(p::AbstractVector{T}, f::AbstractVector{T}) where T<:AbstractFloat
     p = [0.0; p]
     f = [Inf; f]
     i2 = length(f)
@@ -432,7 +432,7 @@ Convex Decreasing π0 estimator
 
 ConvexDecreasing(gridsize, xtol, maxiter)
 """
-immutable ConvexDecreasing <: Pi0Estimator
+struct ConvexDecreasing <: Pi0Estimator
     gridsize::Int64
     xtol::Float64
     maxiter::Int64
@@ -448,13 +448,13 @@ end
 
 ConvexDecreasing() = ConvexDecreasing(100, 1e-5, 10000)
 
-immutable ConvexDecreasingFit <: Pi0Fit
+struct ConvexDecreasingFit <: Pi0Fit
     π0::Float64
     param::AbstractVector{Float64}
     is_converged::Bool
 end
 
-function fit{T<:AbstractFloat}(pi0estimator::ConvexDecreasing, pValues::AbstractVector{T})
+function fit(pi0estimator::ConvexDecreasing, pValues::AbstractVector{T}) where T<:AbstractFloat
     π0, param, is_converged = convex_decreasing(pValues,
                                                 pi0estimator.gridsize,
                                                 pi0estimator.xtol,
@@ -462,7 +462,7 @@ function fit{T<:AbstractFloat}(pi0estimator::ConvexDecreasing, pValues::Abstract
     return ConvexDecreasingFit(π0, param, is_converged)
 end
 
-function estimate_pi0{T<:AbstractFloat}(pValues::PValues{T}, pi0estimator::ConvexDecreasing)
+function estimate_pi0(pValues::PValues{T}, pi0estimator::ConvexDecreasing) where T<:AbstractFloat
     estimate_pi0(fit(pi0estimator, pValues))
 end
 
@@ -471,10 +471,10 @@ function estimate_pi0(pi0fit::ConvexDecreasingFit)
     return pi0
 end
 
-function convex_decreasing{T<:AbstractFloat}(pValues::AbstractVector{T},
-                                             gridsize::Integer = 100,
-                                             xtol::AbstractFloat = 1e-5,
-                                             maxiter::Integer = 10000)
+function convex_decreasing(pValues::AbstractVector{T},
+                           gridsize::Integer = 100,
+                           xtol::AbstractFloat = 1e-5,
+                           maxiter::Integer = 10000) where T<:AbstractFloat
 
     n = length(pValues)
     p = sort(pValues)
@@ -543,6 +543,6 @@ function decide(f_p::Vector{Float64}, f_theta_p::Vector{Float64}, ε::Float64)
     return sum( @. ( f_p[idx] - f_theta_p[idx] ) / ( (1-ε)*f_p[idx] + ε*f_theta_p[idx] ) )
 end
 
-function triangular_weighting{T<:AbstractFloat}(x::Vector{T}, mid::T)
+function triangular_weighting(x::Vector{T}, mid::T) where T<:AbstractFloat
     return @. 2 / mid^2 * (mid-x) * (x<mid)
 end

--- a/src/pval-adjustment.jl
+++ b/src/pval-adjustment.jl
@@ -2,14 +2,17 @@
 
 # promotion from float vectors to PValues type
 
-adjust{T<:AbstractFloat, M<:PValueAdjustment}(pvals::Vector{T}, method::M) = adjust(PValues(pvals), method)
+function adjust(pvals::Vector{T}, method::M) where {T<:AbstractFloat, M<:PValueAdjustment}
+    adjust(PValues(pvals), method)
+end
 
-adjust{T<:AbstractFloat, M<:PValueAdjustment}(pvals::Vector{T}, n::Integer, method::M) = adjust(PValues(pvals), n, method)
-
+function adjust(pvals::Vector{T}, n::Integer, method::M) where {T<:AbstractFloat, M<:PValueAdjustment}
+    adjust(PValues(pvals), n, method)
+end
 
 # Bonferroni
 
-immutable Bonferroni <: PValueAdjustment
+struct Bonferroni <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::Bonferroni) = adjust(pvals, length(pvals), method)
@@ -25,7 +28,7 @@ end
 
 # Benjamini-Hochberg
 
-immutable BenjaminiHochberg <: PValueAdjustment
+struct BenjaminiHochberg <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::BenjaminiHochberg) = adjust(pvals, length(pvals), method)
@@ -49,7 +52,7 @@ bejamini_hochberg_step(p::AbstractFloat, i::Integer, k::Integer, n::Integer) = p
 
 # Benjamini-Hochberg Adaptive
 
-immutable BenjaminiHochbergAdaptive <: PValueAdjustment
+struct BenjaminiHochbergAdaptive <: PValueAdjustment
     pi0estimator::Pi0Estimator
 end
 
@@ -68,7 +71,7 @@ end
 
 # Benjamini-Yekutieli
 
-immutable BenjaminiYekutieli <: PValueAdjustment
+struct BenjaminiYekutieli <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::BenjaminiYekutieli) = adjust(pvals, length(pvals), method)
@@ -92,7 +95,7 @@ benjamini_yekutieli_step(p::AbstractFloat, i::Integer, k::Integer, n::Integer) =
 
 # Benjamini-Liu
 
-immutable BenjaminiLiu <: PValueAdjustment
+struct BenjaminiLiu <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::BenjaminiLiu) = adjust(pvals, length(pvals), method)
@@ -121,7 +124,7 @@ end
 
 # Hochberg
 
-immutable Hochberg <: PValueAdjustment
+struct Hochberg <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::Hochberg) = adjust(pvals, length(pvals), method)
@@ -145,7 +148,7 @@ hochberg_step(p::AbstractFloat, i::Integer, k::Integer, n::Integer) = p * (n-k+i
 
 # Holm
 
-immutable Holm <: PValueAdjustment
+struct Holm <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::Holm) = adjust(pvals, length(pvals), method)
@@ -169,7 +172,7 @@ holm_step(p::AbstractFloat, i::Integer, k::Integer, n::Integer) = p * (n-i+1)
 
 # Hommel
 
-immutable Hommel <: PValueAdjustment
+struct Hommel <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::Hommel) = adjust(pvals, length(pvals), method)
@@ -201,7 +204,7 @@ end
 
 # Sidak
 
-immutable Sidak <: PValueAdjustment
+struct Sidak <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::Sidak) = adjust(pvals, length(pvals), method)
@@ -216,7 +219,7 @@ end
 
 # Forward Stop
 
-immutable ForwardStop <: PValueAdjustment
+struct ForwardStop <: PValueAdjustment
 end
 
 adjust(pvals::PValues, method::ForwardStop) = adjust(pvals, length(pvals), method)
@@ -235,7 +238,7 @@ forwardstop_step(p::AbstractFloat, i::Integer, k::Integer, n::Integer) = p * 1/(
 
 
 # Barber-Candès
-immutable BarberCandes <: PValueAdjustment
+struct BarberCandes <: PValueAdjustment
 end
 
 function adjust(pvals::PValues, method::BarberCandes)
@@ -276,7 +279,7 @@ function adjust(pvals::PValues, method::BarberCandes)
 end
 
 # as test, inefficient implementation
-function barber_candes_brute_force{T<:AbstractFloat}(pvals::AbstractVector{T})
+function barber_candes_brute_force(pvals::AbstractVector{T}) where T<:AbstractFloat
     n = length(pvals)
     sorted_indexes, original_order = reorder(pvals)
     sorted_pvals = pvals[sorted_indexes]
@@ -299,7 +302,7 @@ identity_step(p::AbstractFloat, i::Integer, k::Integer, n::Integer) = p
 
 # step-up / step-down
 
-function stepup!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, stepfun::Function, k::Integer, n::Integer)
+function stepup!(sortedPValues::AbstractVector{T}, stepfun::Function, k::Integer, n::Integer) where T<:AbstractFloat
     sortedPValues[k] = stepfun(sortedPValues[k], 0, k, n)
     for i in 1:(k-1)
         sortedPValues[k-i] = min.(sortedPValues[k-i+1], stepfun(sortedPValues[k-i], i, k, n))
@@ -307,7 +310,7 @@ function stepup!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, stepfun::Fu
     return sortedPValues
 end
 
-function stepdown!{T<:AbstractFloat}(sortedPValues::AbstractVector{T}, stepfun::Function, k::Integer, n::Integer)
+function stepdown!(sortedPValues::AbstractVector{T}, stepfun::Function, k::Integer, n::Integer) where T<:AbstractFloat
     sortedPValues[1] = stepfun(sortedPValues[1], 1, k, n)
     for i in 2:k
         sortedPValues[i] = max.(sortedPValues[i-1], stepfun(sortedPValues[i], i, k, n))

--- a/src/qvalue.jl
+++ b/src/qvalue.jl
@@ -1,6 +1,6 @@
 ## qValues ##
 
-function qValues{T<:AbstractFloat}(pValues::AbstractVector{T}, pi0::AbstractFloat, pfdr::Bool = false)
+function qValues(pValues::AbstractVector{T}, pi0::AbstractFloat, pfdr::Bool = false) where T<:AbstractFloat
     valid_pvalues(pValues)
     valid_pvalues([pi0])
     n = length(pValues)

--- a/src/types.jl
+++ b/src/types.jl
@@ -13,12 +13,12 @@ abstract type PValueCombination end
 
 ## PValues
 
-immutable PValues{T<:AbstractFloat} <: AbstractVector{T}
+struct PValues{T<:AbstractFloat} <: AbstractVector{T}
     values::AbstractVector{T}
     min::T
     max::T
 
-    function(::Type{PValues}){T}(values::AbstractVector{T})
+    function(::Type{PValues})(values::AbstractVector{T}) where T
         min, max = extrema(values)
         if min < 0.0 || max > 1.0
             throw(DomainError())
@@ -27,10 +27,10 @@ immutable PValues{T<:AbstractFloat} <: AbstractVector{T}
     end
 end
 
-Base.convert{T<:AbstractFloat}(::Type{PValues}, x::AbstractVector{T}) = PValues(x)
+Base.convert(::Type{PValues}, x::AbstractVector{T}) where T<:AbstractFloat = PValues(x)
 
 Base.size(pv::PValues) = (length(pv.values), )
-Base.IndexStyle{T<:PValues}(::Type{T}) = IndexLinear()
+Base.IndexStyle(::Type{T}) where T<:PValues = IndexLinear()
 Base.getindex(pv::PValues, i::Integer) = pv.values[i]
 Base.setindex!(pv::PValues, x::AbstractFloat, i::Integer) =
     throw(ErrorException("Modification of values is not permitted"))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 ## utility functions ##
 
-function reorder{T<:Real}(values::AbstractVector{T})
+function reorder(values::AbstractVector{T}) where T<:Real
     newOrder = sortperm(values)
     oldOrder = sortperm(newOrder)
     return newOrder, oldOrder
@@ -31,7 +31,7 @@ function unsort(x; kws...)
 end
 
 
-function valid_pvalues{T<:AbstractFloat}(x::AbstractVector{T})
+function valid_pvalues(x::AbstractVector{T}) where T<:AbstractFloat
     if !isin(x)
         throw(DomainError())
     end
@@ -42,13 +42,13 @@ function isin(x::Real, lower::Real = 0., upper::Real = 1.)
     x >= lower && x <= upper
 end
 
-function isin{T<:Real}(x::AbstractVector{T}, lower::Real = 0., upper::Real = 1.)
+function isin(x::AbstractVector{T}, lower::Real = 0., upper::Real = 1.) where T<:Real
     ex = extrema(x)
     ex[1] >= lower && ex[2] <= upper
 end
 
 
-function isotonic_regression_reference{T<:AbstractFloat}(y::AbstractVector{T}, w::AbstractVector{T})
+function isotonic_regression_reference(y::AbstractVector{T}, w::AbstractVector{T}) where T<:AbstractFloat
     # TODO ignore zero weights
     y = copy(y)
     w = copy(w)
@@ -72,12 +72,12 @@ function isotonic_regression_reference{T<:AbstractFloat}(y::AbstractVector{T}, w
     return yisotonic
 end
 
-function isotonic_regression_reference{T<:AbstractFloat}(y::AbstractVector{T})
+function isotonic_regression_reference(y::AbstractVector{T}) where T<:AbstractFloat
     isotonic_regression_reference(y, ones(y))
 end
 
 
-function isotonic_regression{T<:AbstractFloat}(y::AbstractVector{T}, weights::AbstractVector{T})
+function isotonic_regression(y::AbstractVector{T}, weights::AbstractVector{T}) where T<:AbstractFloat
     n = length(y)
     if n <= 1
         return y
@@ -118,12 +118,12 @@ function isotonic_regression{T<:AbstractFloat}(y::AbstractVector{T}, weights::Ab
     return y
 end
 
-function isotonic_regression{T<:AbstractFloat}(y::AbstractVector{T})
+function isotonic_regression(y::AbstractVector{T}) where T<:AbstractFloat
     isotonic_regression(y, ones(y))
 end
 
 
-function grenander{T<:AbstractFloat}(pv::AbstractVector{T})
+function grenander(pv::AbstractVector{T}) where T<:AbstractFloat
     pv_sorted = sort(pv)
     # ecdf that handles duplicated values
     pv_sorted_unique, counts = rle(pv_sorted)

--- a/test/test-combinations.jl
+++ b/test/test-combinations.jl
@@ -46,8 +46,8 @@ using Base.Test
 
     @testset "$(method)" for method in keys(ref2)
 
-        @test issubtype(method, PValueCombination)
-        @test issubtype(typeof(method()), PValueCombination)
+        @test method <: PValueCombination
+        @test typeof(method()) <: PValueCombination
 
         ref = ref1[method]
         @test isapprox( combine(PValues(p1), method()), ref, atol = 1e-8)
@@ -75,7 +75,7 @@ using Base.Test
         @test_throws MethodError WilkinsonCombination()
         @test_throws ArgumentError WilkinsonCombination(0)
 
-        @test issubtype(typeof(method), PValueCombination)
+        @test typeof(method) <: PValueCombination
 
         # Wilkinson with rank = 1 is Tippett's method
         ref = ref1[TippettCombination]
@@ -117,7 +117,7 @@ using Base.Test
 
         padj_comb = MinimumCombination( p_adjustment() )
 
-        @test issubtype(typeof(padj_comb), PValueCombination)
+        @test typeof(padj_comb) <: PValueCombination
 
         @test isapprox( combine(PValues(p1), padj_comb), ref1[p_combination], atol = 1e-8)
         @test isapprox( combine(p1, padj_comb), ref1[p_combination], atol = 1e-8)

--- a/test/test-pi0-estimators.jl
+++ b/test/test-pi0-estimators.jl
@@ -20,8 +20,8 @@ using StatsBase
 
     @testset "Storey π0" begin
 
-        @test issubtype(typeof(Storey()), Pi0Estimator)
-        @test issubtype(typeof(Storey(0.5)), Pi0Estimator)
+        @test typeof(Storey()) <: Pi0Estimator
+        @test typeof(Storey(0.5)) <: Pi0Estimator
         @test estimate_pi0(p, Storey(0.2)) ≈ 0.6
         @test estimate_pi0(p, Storey(0.0)) ≈ 1.0
         @test estimate_pi0(p, Storey(1.0)) ≈ 1.0
@@ -42,7 +42,7 @@ using StatsBase
 
         q = 0.1
 
-        @test issubtype(typeof(StoreyBootstrap()), Pi0Estimator)
+        @test typeof(StoreyBootstrap()) <: Pi0Estimator
 
         @test estimate_pi0(p, StoreyBootstrap()) ≈ 0.6
         @test estimate_pi0(p0, StoreyBootstrap()) ≈ 1.0
@@ -69,7 +69,7 @@ using StatsBase
 
     @testset "LeastSlope π0" begin
 
-        @test issubtype(typeof(LeastSlope()), Pi0Estimator)
+        @test typeof(LeastSlope()) <: Pi0Estimator
 
         ## checked against structSSI::pi0.lsl
         @test isapprox( estimate_pi0(p, LeastSlope()), 0.62, atol = 1e-2 )
@@ -110,7 +110,7 @@ using StatsBase
 
         alpha = 0.05
 
-        @test issubtype(typeof(TwoStep(alpha)), Pi0Estimator)
+        @test typeof(TwoStep(alpha)) <: Pi0Estimator
 
         ## checked against mutoss::TSBKY_pi0_est
         @test estimate_pi0(p, TwoStep()) ≈ 0.665
@@ -149,8 +149,8 @@ using StatsBase
         # [1] 0.5714286
         # ```
 
-        @test issubtype(typeof(RightBoundary()), Pi0Estimator)
-        @test issubtype(typeof(RightBoundary(lambdas)), Pi0Estimator)
+        @test typeof(RightBoundary()) <: Pi0Estimator
+        @test typeof(RightBoundary(lambdas)) <: Pi0Estimator
 
         # only eps because pi0 package uses right closed histograms
         @test isapprox( estimate_pi0(p, RightBoundary(lambdas)), 0.5714286, atol = 0.02 )
@@ -172,8 +172,8 @@ using StatsBase
 
     @testset "CensoredBUM π0" begin
 
-        @test issubtype(typeof(CensoredBUM()), Pi0Estimator)
-        @test issubtype(typeof(CensoredBUM(0.2, 0.1)), Pi0Estimator)
+        @test typeof(CensoredBUM()) <: Pi0Estimator
+        @test typeof(CensoredBUM(0.2, 0.1)) <: Pi0Estimator
 
         @test isapprox( estimate_pi0(p, CensoredBUM()), 0.55797, atol = 1e-5 )
         @test isapprox( estimate_pi0(p0, CensoredBUM()), 1.0, atol = 1e-5 )
@@ -197,7 +197,7 @@ using StatsBase
         @test_throws DomainError CensoredBUM(0.5, 0.05, 1e-6, -10)
 
         f = fit(CensoredBUM(), p)
-        @test issubtype(typeof(f), CensoredBUMFit)
+        @test typeof(f) <: CensoredBUMFit
         @test isapprox( f.π0, 0.55797, atol = 1e-5 )
 
         # denominator becomes 0 if all p-values are 1
@@ -224,7 +224,7 @@ using StatsBase
         ## test case that does not converge
         @test isnan(estimate_pi0(p, BUM(0.5, 1e-6, 2)))
 
-        @test issubtype(typeof(BUM()), Pi0Estimator)
+        @test typeof(BUM()) <: Pi0Estimator
 
         @test_throws DomainError BUM(-0.5)
         @test_throws DomainError BUM(1.5)
@@ -234,7 +234,7 @@ using StatsBase
 
     @testset "FlatGrenander π0" begin
 
-        @test issubtype(typeof(FlatGrenander()), Pi0Estimator)
+        @test typeof(FlatGrenander()) <: Pi0Estimator
 
         pu = collect(0.1:0.05:0.9)
         @test estimate_pi0(pu, FlatGrenander()) ≈ 1.0
@@ -274,8 +274,8 @@ using StatsBase
 
     @testset "ConvexDecreasing π0" begin
 
-        @test issubtype(typeof(ConvexDecreasing()), Pi0Estimator)
-        @test issubtype(typeof(ConvexDecreasing(100, 1e-6, 1000)), Pi0Estimator)
+        @test typeof(ConvexDecreasing()) <: Pi0Estimator
+        @test typeof(ConvexDecreasing(100, 1e-6, 1000)) <: Pi0Estimator
 
         @test isapprox( estimate_pi0(p, ConvexDecreasing()), 0.5739054, atol = 1e-4)
         @test isapprox( estimate_pi0(p0, ConvexDecreasing()), 1.0, atol = 1e-6 )
@@ -292,7 +292,7 @@ using StatsBase
         @test_throws DomainError ConvexDecreasing(100, 0.01, -1000)
 
         f = fit(ConvexDecreasing(), p)
-        @test issubtype(typeof(f), ConvexDecreasingFit)
+        @test typeof(f) <: ConvexDecreasingFit
         @test isapprox( f.π0, 0.5739054, atol = 1e-4 )
 
     end

--- a/test/test-pval-adjustment.jl
+++ b/test/test-pval-adjustment.jl
@@ -48,8 +48,8 @@ using Base.Test
 
     @testset "pvalue adjustment $method" for method in keys(ref1)
 
-        @test issubtype(method, PValueAdjustment)
-        @test issubtype(typeof(method()), PValueAdjustment)
+        @test method <: PValueAdjustment
+        @test typeof(method()) <: PValueAdjustment
 
         @test_throws MethodError method(0.1)
 


### PR DESCRIPTION
- Adopt new julia syntax around types, methods and parameters
- Use `SpecialFunctions` which is the new home of the `digamma` function