### PR TITLE
Define return types for p-value combinations

### DIFF
--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -1,14 +1,14 @@
 ### Combination methods for p-values ###
 
-function combine(pValues::AbstractVector{T}, method::M) where {T<:AbstractFloat, M<:PValueCombination}
+function combine(pValues::AbstractVector{T}, method::M)::T where {T<:AbstractFloat, M<:PValueCombination}
     combine(PValues(pValues), method)
 end
 
-function combine(pValues::AbstractVector{T}, weights::Weights, method::M) where {T<:AbstractFloat, M<:PValueCombination}
+function combine(pValues::AbstractVector{T}, weights::Weights, method::M)::T where {T<:AbstractFloat, M<:PValueCombination}
     combine(PValues(pValues), weights, method)
 end
 
-function combine(pValues::AbstractVector{T}, weights::AbstractVector{R}, method::M) where {T<:AbstractFloat, R<:Real, M<:PValueCombination}
+function combine(pValues::AbstractVector{T}, weights::AbstractVector{R}, method::M)::T where {T<:AbstractFloat, R<:Real, M<:PValueCombination}
     combine(PValues(pValues), weights, method)
 end
 
@@ -18,7 +18,7 @@ end
 struct FisherCombination <: PValueCombination
 end
 
-function combine(pValues::PValues{T}, method::FisherCombination) where T<:AbstractFloat
+function combine(pValues::PValues{T}, method::FisherCombination)::T where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -37,7 +37,7 @@ end
 struct LogitCombination <: PValueCombination
 end
 
-function combine(pValues::PValues{T}, method::LogitCombination) where T<:AbstractFloat
+function combine(pValues::PValues{T}, method::LogitCombination)::T where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -57,7 +57,7 @@ end
 struct StoufferCombination <: PValueCombination
 end
 
-function combine(pValues::PValues{T}, method::StoufferCombination) where T<:AbstractFloat
+function combine(pValues::PValues{T}, method::StoufferCombination)::T where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -71,7 +71,7 @@ function combine(pValues::PValues{T}, method::StoufferCombination) where T<:Abst
     return p
 end
 
-function combine(pValues::PValues{T}, weights::Vector{T}, method::StoufferCombination) where T<:AbstractFloat
+function combine(pValues::PValues{T}, weights::Vector{T}, method::StoufferCombination)::T where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -85,7 +85,7 @@ function combine(pValues::PValues{T}, weights::Vector{T}, method::StoufferCombin
     return p
 end
 
-function combine(pValues::PValues{T}, weights::Weights, method::StoufferCombination) where T<:AbstractFloat
+function combine(pValues::PValues{T}, weights::Weights, method::StoufferCombination)::T where T<:AbstractFloat
     combine(pValues, values(weights), method)
 end
 
@@ -95,7 +95,7 @@ end
 struct TippettCombination <: PValueCombination
 end
 
-function combine(pValues::PValues{T}, method::TippettCombination) where T<:AbstractFloat
+function combine(pValues::PValues{T}, method::TippettCombination)::T where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -110,7 +110,7 @@ end
 struct SimesCombination <: PValueCombination
 end
 
-function combine(pValues::PValues{T}, method::SimesCombination) where T<:AbstractFloat
+function combine(pValues::PValues{T}, method::SimesCombination)::T where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -134,7 +134,7 @@ struct WilkinsonCombination <: PValueCombination
     end
 end
 
-function combine(pValues::PValues{T}, method::WilkinsonCombination) where T<:AbstractFloat
+function combine(pValues::PValues{T}, method::WilkinsonCombination)::T where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -155,7 +155,7 @@ struct MinimumCombination <: PValueCombination
     adjustment::PValueAdjustment
 end
 
-function combine(pValues::PValues{T}, method::MinimumCombination) where T<:AbstractFloat
+function combine(pValues::PValues{T}, method::MinimumCombination)::T where T<:AbstractFloat
     n = length(pValues)
     if n == 1
         return pValues[1]

--- a/test/test-combinations.jl
+++ b/test/test-combinations.jl
@@ -47,7 +47,6 @@ using Base.Test
     @testset "$(method)" for method in keys(ref2)
 
         @test method <: PValueCombination
-        @test typeof(method()) <: PValueCombination
 
         ref = ref1[method]
         @test isapprox( combine(PValues(p1), method()), ref, atol = 1e-8)
@@ -64,6 +63,14 @@ using Base.Test
 
         @test combine(PValues(p_single), method()) == p_single[1]
         @test combine(p_single, method()) == p_single[1]
+
+        for T in (Float32, Float64)
+            pv = rand(T, 1)
+            @test isa( combine(PValues(pv), method()), T)
+
+            pv = Vector{T}(p1)
+            @test isa( combine(PValues(pv), method()), T)
+        end
 
     end
 
@@ -96,6 +103,14 @@ using Base.Test
 
         @test combine(PValues(p_single), method) == p_single[1]
         @test combine(p_single, method) == p_single[1]
+
+        for T in (Float32, Float64)
+            pv = rand(T, 1)
+            @test isa( combine(PValues(pv), method), T)
+
+            pv = Vector{T}(p1)
+            @test isa( combine(PValues(pv), method), T)
+        end
 
         # reference values computed with `metap::wilkinsonp(p, r, alpha = 1e-16)$p`
         ref = [0.03940399, 0.01401875, 0.0272, 0.4096]
@@ -131,6 +146,14 @@ using Base.Test
 
         @test combine(PValues(p_single), padj_comb) == p_single[1]
         @test combine(p_single, padj_comb) == p_single[1]
+
+        for T in (Float32, Float64)
+            pv = rand(T, 1)
+            @test isa( combine(PValues(pv), padj_comb), T)
+
+            pv = Vector{T}(p1)
+            @test isa( combine(PValues(pv), padj_comb), T)
+        end
 
     end
 


### PR DESCRIPTION
`combine(PValues{T}, ...)` now always returns a p-value of type `T`.