### PR TITLE
Simplify the step functions for p-value adjustments

### DIFF
--- a/src/pval-adjustment.jl
+++ b/src/pval-adjustment.jl
@@ -37,11 +37,11 @@ function adjust(pValues::PValues, n::Integer, method::BenjaminiHochberg)
     if k <= 1
         return pValues
     end
-    sortedIndexes, originalOrder = reorder(pValues)
-    sortedPValues = pValues[sortedIndexes]
-    sortedPValues .*= n ./ (1:k)
-    stepup!(sortedPValues)
-    pAdjusted = min.(sortedPValues[originalOrder], 1)
+    sortedOrder, originalOrder = reorder(pValues)
+    pAdjusted = pValues[sortedOrder]
+    pAdjusted .*= n ./ (1:k)
+    stepup!(pAdjusted)
+    pAdjusted = min.(pAdjusted[originalOrder], 1)
     return pAdjusted
 end
 
@@ -79,11 +79,11 @@ function adjust(pValues::PValues, n::Integer, method::BenjaminiYekutieli)
     if k <= 1
         return pValues
     end
-    sortedIndexes, originalOrder = reorder(pValues)
-    sortedPValues = pValues[sortedIndexes]
-    sortedPValues .*= harmonic_number(n) .* n ./ (1:k)
-    stepup!(sortedPValues)
-    pAdjusted = min.(sortedPValues[originalOrder], 1)
+    sortedOrder, originalOrder = reorder(pValues)
+    pAdjusted = pValues[sortedOrder]
+    pAdjusted .*= harmonic_number(n) .* n ./ (1:k)
+    stepup!(pAdjusted)
+    pAdjusted = min.(pAdjusted[originalOrder], 1)
     return pAdjusted
 end
 
@@ -101,14 +101,14 @@ function adjust(pValues::PValues, n::Integer, method::BenjaminiLiu)
     if n <= 1
         return pValues
     end
-    sortedIndexes, originalOrder = reorder(pValues)
-    sortedPValues = pValues[sortedIndexes]
+    sortedOrder, originalOrder = reorder(pValues)
+    pAdjusted = pValues[sortedOrder]
     # a bit more involved because cutoffs at significance α have the form:
     # P_(i) <= 1- [1 - min(1, m/(m-i+1)α)]^{1/(m-i+1)}
     s = n .- (1:k) .+ 1
-    sortedPValues = (1 .- (1 .- sortedPValues) .^ s) .* s ./ n
-    stepdown!(sortedPValues)
-    pAdjusted = min.(sortedPValues[originalOrder], 1)
+    pAdjusted = (1 .- (1 .- pAdjusted) .^ s) .* s ./ n
+    stepdown!(pAdjusted)
+    pAdjusted = min.(pAdjusted[originalOrder], 1)
     return pAdjusted
 end
 
@@ -126,11 +126,11 @@ function adjust(pValues::PValues, n::Integer, method::Hochberg)
     if k <= 1
         return pValues
     end
-    sortedIndexes, originalOrder = reorder(pValues)
-    sortedPValues = pValues[sortedIndexes]
-    sortedPValues .*= (n .- (1:k) .+ 1)
-    stepup!(sortedPValues)
-    pAdjusted = min.(sortedPValues[originalOrder], 1)
+    sortedOrder, originalOrder = reorder(pValues)
+    pAdjusted = pValues[sortedOrder]
+    pAdjusted .*= (n .- (1:k) .+ 1)
+    stepup!(pAdjusted)
+    pAdjusted = min.(pAdjusted[originalOrder], 1)
     return pAdjusted
 end
 
@@ -148,11 +148,11 @@ function adjust(pValues::PValues, n::Integer, method::Holm)
     if n <= 1
         return pValues
     end
-    sortedIndexes, originalOrder = reorder(pValues)
-    sortedPValues = pValues[sortedIndexes]
-    sortedPValues .*= (n .- (1:k) .+ 1)
-    stepdown!(sortedPValues)
-    pAdjusted = min.(sortedPValues[originalOrder], 1)
+    sortedOrder, originalOrder = reorder(pValues)
+    pAdjusted = pValues[sortedOrder]
+    pAdjusted .*= (n .- (1:k) .+ 1)
+    stepdown!(pAdjusted)
+    pAdjusted = min.(pAdjusted[originalOrder], 1)
     return pAdjusted
 end
 
@@ -171,19 +171,19 @@ function adjust(pValues::PValues, n::Integer, method::Hommel)
         return pValues
     end
     pValues = vcat(pValues, fill(1.0, n-k))  # TODO avoid sorting of ones
-    sortedIndexes, originalOrder = reorder(pValues)
-    sortedPValues = pValues[sortedIndexes]
+    sortedOrder, originalOrder = reorder(pValues)
+    pAdjusted = pValues[sortedOrder]
     q = fill(minimum(n .* pValues./(1:n)), n)
     pa = fill(q[1], n)
     for j in (n-1):-1:2
         ij = 1:(n-j+1)
         i2 = (n-j+2):n
-        q1 = minimum(j .* sortedPValues[i2]./((2:j)))
-        q[ij] = min.(j .* sortedPValues[ij], q1)
+        q1 = minimum(j .* pAdjusted[i2]./((2:j)))
+        q[ij] = min.(j .* pAdjusted[ij], q1)
         q[i2] = q[n-j+1]
         pa = max.(pa, q)
     end
-    pAdjusted = max.(pa, sortedPValues)[originalOrder[1:k]]
+    pAdjusted = max.(pa, pAdjusted)[originalOrder[1:k]]
     return pAdjusted
 end
 

--- a/test/test-pval-adjustment.jl
+++ b/test/test-pval-adjustment.jl
@@ -101,13 +101,32 @@ using Base.Test
 
     @testset "BarberCandès #2:" begin
         for k = 1:5
-          srand(k)
-          pv = rand(BetaUniformMixtureModel(0.5, 0.5, 7.0), 40)
-          @test isapprox(adjust(pv, BarberCandes()),
-                MultipleTesting.barber_candes_brute_force(pv), atol=1e-9)
+            srand(k)
+            pv = rand(BetaUniformMixtureModel(0.5, 0.5, 7.0), 40)
+            @test isapprox(adjust(pv, BarberCandes()),
+                           MultipleTesting.barber_candes_brute_force(pv), atol=1e-9)
         end
     end
-end
 
+
+    @testset "Step-up/down" begin
+
+        x        = [1.0, 2.0, 2.0, 5.0, 4.0, 5.0, 7.0]
+        ref_up   = [1.0, 2.0, 2.0, 4.0, 4.0, 5.0, 7.0]
+        ref_down = [1.0, 2.0, 2.0, 5.0, 5.0, 5.0, 7.0]
+
+        # step-up
+        y = copy(x)
+        MultipleTesting.stepup!(y)
+        @test y == ref_up
+
+        # step-down
+        y = copy(x)
+        MultipleTesting.stepdown!(y)
+        @test y == ref_down
+
+    end
+
+end
 
 end


### PR DESCRIPTION
- The modification of the p-values is now part of the main `adjust` functions, no additional `_step` functions are needed: This gives us fewer functions to worry about, cleaner code and better performance (e.g. we only have to compute the harmonic number once per adjustment and don't need to recompute the same value for each call of the step function).
- `stepup!` and `stepdown!` are now only performing the monotisation with `cummin` and `cummax`; the modification of the p-values happens beforehand.