### PR TITLE
Unify methods for weighted Stouffer combination

### DIFF
--- a/src/combinations.jl
+++ b/src/combinations.jl
@@ -4,14 +4,6 @@ function combine(pValues::AbstractVector{T}, method::M)::T where {T<:AbstractFlo
     combine(PValues(pValues), method)
 end
 
-function combine(pValues::AbstractVector{T}, weights::Weights, method::M)::T where {T<:AbstractFloat, M<:PValueCombination}
-    combine(PValues(pValues), weights, method)
-end
-
-function combine(pValues::AbstractVector{T}, weights::AbstractVector{R}, method::M)::T where {T<:AbstractFloat, R<:Real, M<:PValueCombination}
-    combine(PValues(pValues), weights, method)
-end
-
 
 ## Fisher combination ##
 
@@ -71,7 +63,7 @@ function combine(pValues::PValues{T}, method::StoufferCombination)::T where T<:A
     return p
 end
 
-function combine(pValues::PValues{T}, weights::Vector{T}, method::StoufferCombination)::T where T<:AbstractFloat
+function combine(pValues::PValues{T}, weights::AbstractVector{R}, method::StoufferCombination)::T where {T<:AbstractFloat, R<:Real}
     n = length(pValues)
     if n == 1
         return pValues[1]
@@ -85,8 +77,8 @@ function combine(pValues::PValues{T}, weights::Vector{T}, method::StoufferCombin
     return p
 end
 
-function combine(pValues::PValues{T}, weights::Weights, method::StoufferCombination)::T where T<:AbstractFloat
-    combine(pValues, values(weights), method)
+function combine(pValues::AbstractVector{T}, weights::AbstractVector{R}, method::StoufferCombination)::T where {T<:AbstractFloat, R<:Real}
+    combine(PValues(pValues), weights, method)
 end
 
 


### PR DESCRIPTION
Drops the generic `combine` methods with weights: Only the Stouffer method currently supports weights.

Unifies the `combine` methods with `StatsBase.Weights` and `Vector` weights to support only an `AbstractVector` input: This handles both existing cases with one method, and provides a more flexible interface for additional types of weights.