### PR TITLE
Enable fast finishing for CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,7 @@ environment:
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 matrix:
+  fast_finish: true
   allow_failures:
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ julia:
   - nightly
 
 matrix:
+  fast_finish: true
   allow_failures:
     - julia: nightly
 


### PR DESCRIPTION
Report the build status as soon as possible, don't wait for builds that are allowed to fail.