### PR TITLE
add missing-tolerant adjust method

### DIFF
--- a/src/pval-adjustment.jl
+++ b/src/pval-adjustment.jl
@@ -60,6 +60,13 @@ function adjust(pValues::Vector{T}, method::M) where {T <: AbstractFloat,M <: PV
     return adjust(PValues(pValues), method)
 end
 
+function adjust(pValues::Vector{T}, method::M) where {T <: Union{Missing, AbstractFloat},M <: PValueAdjustment}
+    pValues_out = copy(pValues)
+    pValues_skipmissing = collect(skipmissing(pValues))
+    pValues_out[pValues .!== missing] .= adjust(PValues(pValues_skipmissing), method)
+    return pValues_out
+end
+
 function adjust(pValues::Vector{T}, n::Integer, method::M) where {T <: AbstractFloat,M <: PValueAdjustment}
     return adjust(PValues(pValues), n, method)
 end


### PR DESCRIPTION
This PR addresses issue #108 of including a method ignorant of `missing` values in a vector of P values. The reason this method is necessary/useful is that when using split-apply-combine methods for categorical data grouping when `missing` values are present, situations may arise where one of the grouped vectors contains only missing values and thus the resulting P value would be `missing` as well. 

The introduced method to `adjust` creates a copy of the Pvalue vector, performs the correction `method` on all the non-missing Pvalues, and overwrites the original nonmissing Pvalues in the copied vector, returning the modified copy with all the `missing` values preserved in their original locations. 

```julia
julia> a = [0.1, 0.2, missing, 0.4] ;

julia> adjust(a, Holm())
4-element Array{Union{Missing, Float64},1}:
 0.30000000000000004
 0.4
  missing
 0.4
```
This method should leave the original unaffected:
```julia
julia> b = adjust(rand(10), Holm())
10-element Array{Float64,1}:
 1.0
 1.0
 1.0
 1.0
 1.0
 0.18431430876447497
 1.0
 1.0
 1.0
 1.0
```