### PR TITLE
Improve sorting in p-values adjustment methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- Improve the reordering strategy of p-values in adjustment methods. This change saves one sorting step for all adjustment methods that require sorted p-values. As a result, the performance for these methods is significantly improved.
 - Pin `Documenter` to v0.19 for building of the documentation (#104)
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,12 +1,5 @@
 ## utility functions ##
 
-function reorder(values::AbstractVector{T}) where T <: Real
-    newOrder = sortperm(values)
-    oldOrder = sortperm(newOrder)
-    return newOrder, oldOrder
-end
-
-
 function sort_if_needed(x; kws...)
     if issorted(x; kws...)
         return x

--- a/test/test-pval-adjustment.jl
+++ b/test/test-pval-adjustment.jl
@@ -137,10 +137,10 @@ using Test
         # inefficient implementation for testing
         function barber_candes_brute_force(pValues::AbstractVector{T}) where T <: AbstractFloat
             n = length(pValues)
-            sorted_indexes, original_order = MultipleTesting.reorder(pValues)
-            sorted_pValues = pValues[sorted_indexes]
+            sorted_indexes = sortperm(pValues)
+            pAdjusted = pValues[sorted_indexes]
             estimated_fdrs = fill(1.0, size(pValues))
-            for (i, pv) in enumerate(sorted_pValues)
+            for (i, pv) in enumerate(pAdjusted)
                 if pv >= 0.5
                     break
                 else
@@ -148,7 +148,7 @@ using Test
                 end
             end
             MultipleTesting.stepup!(estimated_fdrs)
-            pAdjusted = clamp.(estimated_fdrs[original_order], 0, 1)
+            pAdjusted[sorted_indexes] = clamp.(estimated_fdrs, 0, 1)
             return pAdjusted
         end
 

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -43,12 +43,16 @@ using Test
     end
 
 
-    @testset "reorder" begin
+    @testset "sorted and original ordering" begin
 
         x = [1, 5, 4, 2, 4, 3]
-        no, oo = MultipleTesting.reorder(x)
-        @test x[no] == sort(x)
-        @test x[no][oo] == x
+        new_order = sortperm(x)
+        y = x[new_order]
+        z = copy(y)
+        z[new_order] = y
+
+        @test y == sort(x)
+        @test z == x
 
     end
 


### PR DESCRIPTION
Improve the reordering strategy of p-values in adjustment methods. This change saves one sorting step for all adjustment methods that require sorted p-values. As a result, the performance for these methods is significantly improved.